### PR TITLE
Fixes issue w/ UIApplication.shared not being supported in iOS App Extensions

### DIFF
--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
@@ -203,7 +203,10 @@ extension SegmentDestination.UploadTaskInfo {
 
 extension UIApplication {
     static var safeShared: UIApplication? {
-        // UIApplication.shared is not available in app extensions.
+        // UIApplication.shared is not available in app extensions so try to get
+        // it in a way that's safe for both.
+        
+        // if we are NOT an app extension, we need to get UIApplication.shared
         if !isAppExtension {
             // getting it like this allows us to avoid the compiler error that would
             // be generated even though we're guarding against app extensions.
@@ -211,6 +214,8 @@ extension UIApplication {
             // so this is the best i could do.
             return UIApplication.value(forKeyPath: "sharedApplication") as? UIApplication
         }
+        // if we ARE an app extension, send back nil since we have no way to get the
+        // application instance.
         return nil
     }
 }

--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
@@ -50,10 +50,9 @@ class iOSLifecycleMonitor: PlatformPlugin {
                                                            UIApplication.backgroundRefreshStatusDidChangeNotification]
 
     required init() {
-        // App extensions can't use UIAppication.shared.
-        if !isAppExtension {
-            application = UIApplication.safeShared
-        }
+        // App extensions can't use UIAppication.shared, so
+        // funnel it through something to check; Could be nil.
+        application = UIApplication.safeShared
         setupListeners()
     }
     

--- a/Sources/Segment/Utilities/Utils.swift
+++ b/Sources/Segment/Utilities/Utils.swift
@@ -13,6 +13,13 @@ internal var isUnitTesting: Bool = {
     return value
 }()
 
+internal var isAppExtension: Bool = {
+    if Bundle.main.bundlePath.hasSuffix(".appex") {
+        return true
+    }
+    return false
+}()
+
 internal func exceptionFailure(_ message: String) {
     if isUnitTesting {
         assertionFailure(message)


### PR DESCRIPTION
- Fixes #34 
- Adds isAppExtension check.
- Changes application values in lifecycle func's to be optional.
- Generally accounts for the possibility that we may not have a UIApplication to pass around.