### PR TITLE
Fix context issue and macOS vendor system miss.

### DIFF
--- a/Sources/Segment/Plugins/Platforms/Vendors/VendorSystem.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/VendorSystem.swift
@@ -68,6 +68,8 @@ internal class VendorSystem {
     static var current: VendorSystem {
         #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         return iOSVendorSystem()
+        #elseif os(macOS)
+        return MacOSVendorSystem()
         #elseif os(watchOS)
         return watchOSVendorSystem()
         #elseif os(Linux)

--- a/Sources/Segment/Startup.swift
+++ b/Sources/Segment/Startup.swift
@@ -37,12 +37,12 @@ extension Analytics: Subscriber {
     internal func platformPlugins() -> [PlatformPlugin]? {
         var plugins = [PlatformPlugin]()
         
+        // add context plugin as well as it's platform specific internally.
+        // this must come first.
+        plugins.append(Context())
+
         // setup lifecycle if desired
         if configuration.values.trackApplicationLifecycleEvents {
-            // add context plugin as well as it's platform specific internally.
-            // this must come first.
-            plugins.append(Context())
-            
             #if os(iOS) || os(tvOS)
             plugins += [iOSLifecycleMonitor(), iOSLifecycleEvents(), DeviceToken()]
             #endif

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -127,13 +127,21 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertNotNil(context)
         XCTAssertNotNil(context?["screen"], "screen missing!")
         XCTAssertNotNil(context?["network"], "network missing!")
-        XCTAssertNotNil(context?["app"], "app missing!")
-        XCTAssertNotNil(context?["locale"], "locale missing!")
         XCTAssertNotNil(context?["os"], "os missing!")
         XCTAssertNotNil(context?["timezone"], "timezone missing!")
-        XCTAssertNotNil(context?["userAgent"], "userAgent missing!")
         XCTAssertNotNil(context?["library"], "library missing!")
         XCTAssertNotNil(context?["device"], "device missing!")
+
+        // this key not present on watchOS (doesn't have webkit)
+        #if !os(watchOS)
+        XCTAssertNotNil(context?["userAgent"], "userAgent missing!")
+        #endif
+        
+        // these keys not present on linux
+        #if !os(Linux)
+        XCTAssertNotNil(context?["app"], "app missing!")
+        XCTAssertNotNil(context?["locale"], "locale missing!")
+        #endif
     }
     
     func testDeviceToken() {

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -111,6 +111,31 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertTrue(anonId.count == 36) // it's a UUID y0.
     }
     
+    func testContext() {
+        let analytics = Analytics(configuration: Configuration(writeKey: "test"))
+        let outputReader = OutputReaderPlugin()
+        analytics.add(plugin: outputReader)
+
+        waitUntilStarted(analytics: analytics)
+        
+        analytics.track(name: "token check")
+        
+        let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
+        let context = trackEvent?.context?.dictionaryValue
+        // Verify that context isn't empty here.
+        // We need to verify the values but will do that in separate platform specific tests.
+        XCTAssertNotNil(context)
+        XCTAssertNotNil(context?["screen"])
+        XCTAssertNotNil(context?["network"])
+        XCTAssertNotNil(context?["app"])
+        XCTAssertNotNil(context?["locale"])
+        XCTAssertNotNil(context?["os"])
+        XCTAssertNotNil(context?["timezone"])
+        XCTAssertNotNil(context?["userAgent"])
+        XCTAssertNotNil(context?["library"])
+        XCTAssertNotNil(context?["device"])
+    }
+    
     func testDeviceToken() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -125,15 +125,15 @@ final class Analytics_Tests: XCTestCase {
         // Verify that context isn't empty here.
         // We need to verify the values but will do that in separate platform specific tests.
         XCTAssertNotNil(context)
-        XCTAssertNotNil(context?["screen"])
-        XCTAssertNotNil(context?["network"])
-        XCTAssertNotNil(context?["app"])
-        XCTAssertNotNil(context?["locale"])
-        XCTAssertNotNil(context?["os"])
-        XCTAssertNotNil(context?["timezone"])
-        XCTAssertNotNil(context?["userAgent"])
-        XCTAssertNotNil(context?["library"])
-        XCTAssertNotNil(context?["device"])
+        XCTAssertNotNil(context?["screen"], "screen missing!")
+        XCTAssertNotNil(context?["network"], "network missing!")
+        XCTAssertNotNil(context?["app"], "app missing!")
+        XCTAssertNotNil(context?["locale"], "locale missing!")
+        XCTAssertNotNil(context?["os"], "os missing!")
+        XCTAssertNotNil(context?["timezone"], "timezone missing!")
+        XCTAssertNotNil(context?["userAgent"], "userAgent missing!")
+        XCTAssertNotNil(context?["library"], "library missing!")
+        XCTAssertNotNil(context?["device"], "device missing!")
     }
     
     func testDeviceToken() {


### PR DESCRIPTION
- Moves the addition of the context plugin OUTSIDE of the lifecycle check. Fixes #41 
- Adds a check to return the macOS vendor system instead of the empty default implementation.
- Adds test to verify context is present with the correct top level keys.