### PR TITLE
Fixes issue w/ amplitude sessionId not working

### DIFF
--- a/Examples/destination_plugins/AmplitudeSession.swift
+++ b/Examples/destination_plugins/AmplitudeSession.swift
@@ -118,12 +118,12 @@ class AmplitudeSession: EventPlugin, iOSLifecycle {
         return returnEvent
     }
     
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(application: UIApplication?) {
         startTimer()
         analytics?.log(message: "Amplitude Session ID: \(sessionID ?? -1)")
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(application: UIApplication?) {
         stopTimer()
     }
 }


### PR DESCRIPTION
When we changed the application param to be optional for app extensions, this one was missed, so it's falling back to the default implementation that does nothing.