### PR TITLE
Integration enable/disable refactor

### DIFF
--- a/Examples/destination_plugins/AmplitudeSession.swift
+++ b/Examples/destination_plugins/AmplitudeSession.swift
@@ -53,7 +53,7 @@ class AmplitudeSession: EventPlugin, iOSLifecycle {
     private let fireTime = TimeInterval(300)
     
     func update(settings: Settings, type: UpdateType) {
-        if settings.isDestinationEnabled(key: key) {
+        if settings.hasIntegrationSettings(key: key) {
             active = true
         } else {
             active = false

--- a/Segment.xcodeproj/project.pbxproj
+++ b/Segment.xcodeproj/project.pbxproj
@@ -502,7 +502,7 @@
 			attributes = {
 				LastSwiftMigration = 9999;
 				LastSwiftUpdateCheck = 1220;
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1310;
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Segment" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/Segment.xcodeproj/xcshareddata/xcschemes/Segment-Package.xcscheme
+++ b/Segment.xcodeproj/xcshareddata/xcschemes/Segment-Package.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -24,6 +24,9 @@ public class Analytics {
     
     public var timeline: Timeline
     
+    /// Initialize this instance of Analytics with a given configuration setup.
+    /// - Parameters:
+    ///    - configuration: The configuration to use
     public init(configuration: Configuration) {
         self.configuration = configuration
         
@@ -44,7 +47,7 @@ public class Analytics {
         _ = timeline.process(incomingEvent: event)
     }
     
-    public func process(event: RawEvent) {
+    internal func process(event: RawEvent) {
         switch event {
         case let e as TrackEvent:
             timeline.process(incomingEvent: e)
@@ -65,6 +68,7 @@ public class Analytics {
 // MARK: - System Modifiers
 
 extension Analytics {
+    /// Returns the anonymousId currently in use.
     public var anonymousId: String {
         if let userInfo: UserInfo = store.currentState() {
             return userInfo.anonymousId
@@ -72,6 +76,7 @@ extension Analytics {
         return ""
     }
     
+    /// Returns the userId that was specified in the last identify call.
     public var userId: String? {
         if let userInfo: UserInfo = store.currentState() {
             return userInfo.userId
@@ -79,6 +84,7 @@ extension Analytics {
         return nil
     }
     
+    /// Returns the traits that were specified in the last identify call.
     public func traits<T: Codable>() -> T? {
         if let userInfo: UserInfo = store.currentState() {
             return userInfo.traits?.codableValue()
@@ -86,6 +92,8 @@ extension Analytics {
         return nil
     }
     
+    /// Tells this instance of Analytics to flush any queued events up to Segment.com.  This command will also
+    /// be sent to each plugin present in the system.
     public func flush() {
         apply { plugin in
             if let p = plugin as? EventPlugin {
@@ -94,6 +102,8 @@ extension Analytics {
         }
     }
     
+    /// Resets this instance of Analytics to a clean slate.  Traits, UserID's, anonymousId, etc are all cleared or reset.  This
+    /// command will also be sent to each plugin present in the system.
     public func reset() {
         store.dispatch(action: UserInfo.ResetAction())
         apply { plugin in
@@ -103,6 +113,22 @@ extension Analytics {
         }
     }
     
+    /// Retrieve the version of this library in use.
+    /// - Returns: A string representing the version in "BREAKING.FEATURE.FIX" format.
+    public func version() -> String {
+        return Analytics.version()
+    }
+    
+    /// Retrieve the version of this library in use.
+    /// - Returns: A string representing the version in "BREAKING.FEATURE.FIX" format.
+    public static func version() -> String {
+        return __segment_version
+    }
+}
+
+extension Analytics {
+    /// Manually retrieve the settings that were supplied from Segment.com.
+    /// - Returns: A Settings object containing integration settings, tracking plan, etc.
     public func settings() -> Settings? {
         var settings: Settings?
         if let system: System = store.currentState() {
@@ -119,12 +145,4 @@ extension Analytics {
         self.store.dispatch(action: System.AddDestinationToSettingsAction(key: plugin.key))
     }
 
-    
-    public func version() -> String {
-        return Analytics.version()
-    }
-    
-    public static func version() -> String {
-        return __segment_version
-    }
 }

--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -111,6 +111,15 @@ extension Analytics {
         return settings
     }
     
+    /// Manually enable a destination plugin.  This is useful when a given DestinationPlugin doesn't have any Segment tie-ins at all.
+    /// This will allow the destination to be processed in the same way within this library.
+    /// - Parameters:
+    ///   - plugin: The destination plugin to enable.
+    public func manuallyEnableDestination(plugin: DestinationPlugin) {
+        self.store.dispatch(action: System.AddDestinationToSettingsAction(key: plugin.key))
+    }
+
+    
     public func version() -> String {
         return Analytics.version()
     }

--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -47,7 +47,10 @@ public class Analytics {
         _ = timeline.process(incomingEvent: event)
     }
     
-    internal func process(event: RawEvent) {
+    /// Process a raw event through the system.  Useful when one needs to queue and replay events at a later time.
+    /// - Parameters:
+    ///   - event: An event conforming to RawEvent that will be processed.
+    public func process(event: RawEvent) {
         switch event {
         case let e as TrackEvent:
             timeline.process(incomingEvent: e)

--- a/Sources/Segment/Plugins.swift
+++ b/Sources/Segment/Plugins.swift
@@ -140,11 +140,6 @@ extension Analytics {
     public func add(plugin: Plugin) -> Plugin {
         plugin.configure(analytics: self)
         timeline.add(plugin: plugin)
-        if !(plugin is SegmentDestination), let destPlugin = plugin as? DestinationPlugin {
-            // need to maintain the list of integrations to inject into payload
-            store.dispatch(action: System.AddIntegrationAction(key: destPlugin.key))
-        }
-        
         return plugin
     }
     
@@ -155,9 +150,6 @@ extension Analytics {
      */
     public func remove(plugin: Plugin) {
         timeline.remove(plugin: plugin)
-        if !(plugin is SegmentDestination), let destPlugin = plugin as? DestinationPlugin {
-            store.dispatch(action: System.RemoveIntegrationAction(key: destPlugin.key))
-        }
     }
     
     public func find<T: Plugin>(pluginType: T.Type) -> T? {

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -147,8 +147,8 @@ extension SegmentDestination {
         guard let plugins = analytics?.timeline.plugins[.destination]?.plugins as? [DestinationPlugin] else { return event }
         guard let customerValues = event.integrations?.dictionaryValue else { return event }
         
-        // take the customer values first.
-        var merged = customerValues
+        var merged = [String: Any]()
+        
         // compare settings to loaded plugins
         for plugin in plugins {
             let hasSettings = integrationSettings.hasIntegrationSettings(forPlugin: plugin)
@@ -159,7 +159,15 @@ extension SegmentDestination {
             }
         }
         
-        return event
+        // apply customer values; the customer is always right!
+        for (key, value) in customerValues {
+            merged[key] = value
+        }
+        
+        var modified = event
+        modified.integrations = try? JSON(merged)
+        
+        return modified
     }
 }
 

--- a/Sources/Segment/Settings.swift
+++ b/Sources/Segment/Settings.swift
@@ -69,8 +69,12 @@ public struct Settings: Codable {
     }
     
     public func hasIntegrationSettings(forPlugin plugin: DestinationPlugin) -> Bool {
+        return hasIntegrationSettings(key: plugin.key)
+    }
+
+    public func hasIntegrationSettings(key: String) -> Bool {
         guard let settings = integrations?.dictionaryValue else { return false }
-        return (settings[plugin.key] != nil)
+        return (settings[key] != nil)
     }
 }
 

--- a/Sources/Segment/Settings.swift
+++ b/Sources/Segment/Settings.swift
@@ -68,12 +68,9 @@ public struct Settings: Codable {
         return integrationSettings(forKey: plugin.key)
     }
     
-    public func isDestinationEnabled(key: String) -> Bool {
+    public func hasIntegrationSettings(forPlugin plugin: DestinationPlugin) -> Bool {
         guard let settings = integrations?.dictionaryValue else { return false }
-        if settings.keys.contains(key) {
-            return true
-        }
-        return false
+        return (settings[plugin.key] != nil)
     }
 }
 
@@ -85,15 +82,7 @@ extension Settings: Equatable {
     }
 }
 
-extension Analytics {
-    /// Manually enable a destination plugin.  This is useful when a given DestinationPlugin doesn't have any Segment tie-ins at all.
-    /// This will allow the destination to be processed in the same way within this library.
-    /// - Parameters:
-    ///   - plugin: The destination plugin to enable.
-    public func manuallyEnableDestination(plugin: DestinationPlugin) {
-        self.store.dispatch(action: System.AddIntegrationAction(key: plugin.key))
-    }
-    
+extension Analytics {     
     internal func update(settings: Settings, type: UpdateType) {
         apply { (plugin) in
             // tell all top level plugins to update.

--- a/Sources/Segment/Timeline.swift
+++ b/Sources/Segment/Timeline.swift
@@ -211,9 +211,9 @@ extension DestinationPlugin {
         return result
     }
     
-    internal func isDestinationEnabled(integrations: JSON?) -> Bool {
+    internal func isDestinationEnabled(event: RawEvent) -> Bool {
         var customerDisabled = false
-        if let disabled: Bool = integrations?.value(forKeyPath: KeyPath(self.key)), disabled == false {
+        if let disabled: Bool = event.integrations?.value(forKeyPath: KeyPath(self.key)), disabled == false {
             customerDisabled = true
         }
         
@@ -231,7 +231,7 @@ extension DestinationPlugin {
         
         var result: E? = nil
         
-        if isDestinationEnabled(integrations: incomingEvent.integrations) {
+        if isDestinationEnabled(event: incomingEvent) {
             // apply .before and .enrichment types first ...
             let beforeResult = timeline.applyPlugins(type: .before, event: incomingEvent)
             let enrichmentResult = timeline.applyPlugins(type: .enrichment, event: beforeResult)

--- a/Sources/Segment/Timeline.swift
+++ b/Sources/Segment/Timeline.swift
@@ -222,7 +222,7 @@ extension DestinationPlugin {
             hasSettings = settings.hasIntegrationSettings(forPlugin: self)
         }
         
-        return (hasSettings && customerDisabled == false)
+        return (hasSettings == true && customerDisabled == false)
     }
 
     internal func process<E: RawEvent>(incomingEvent: E) -> E? {

--- a/Sources/Segment/Timeline.swift
+++ b/Sources/Segment/Timeline.swift
@@ -210,6 +210,20 @@ extension DestinationPlugin {
         }
         return result
     }
+    
+    internal func isDestinationEnabled(integrations: JSON?) -> Bool {
+        var customerDisabled = false
+        if let disabled: Bool = integrations?.value(forKeyPath: KeyPath(self.key)), disabled == false {
+            customerDisabled = true
+        }
+        
+        var hasSettings = false
+        if let settings = analytics?.settings() {
+            hasSettings = settings.hasIntegrationSettings(forPlugin: self)
+        }
+        
+        return (hasSettings && customerDisabled == false)
+    }
 
     internal func process<E: RawEvent>(incomingEvent: E) -> E? {
         // This will process plugins (think destination middleware) that are tied
@@ -217,11 +231,7 @@ extension DestinationPlugin {
         
         var result: E? = nil
         
-        // For destination plugins, we will always have some kind of `settings`,
-        // and if we don't, it means this destination hasn't been setup on app.segment.com,
-        // which in turn ALSO means that we shouldn't be sending events to it.
-
-        if let enabled = analytics?.settings()?.isDestinationEnabled(key: self.key), enabled == true {
+        if isDestinationEnabled(integrations: incomingEvent.integrations) {
             // apply .before and .enrichment types first ...
             let beforeResult = timeline.applyPlugins(type: .before, event: incomingEvent)
             let enrichmentResult = timeline.applyPlugins(type: .enrichment, event: beforeResult)

--- a/Sources/Segment/Types.swift
+++ b/Sources/Segment/Types.swift
@@ -277,14 +277,13 @@ extension RawEvent {
     internal func applyRawEventData(store: Store) -> Self {
         var result: Self = self
         
-        guard let system: System = store.currentState() else { return self }
         guard let userInfo: UserInfo = store.currentState() else { return self }
         
         result.anonymousId = userInfo.anonymousId
         result.userId = userInfo.userId
         result.messageId = UUID().uuidString
         result.timestamp = Date().iso8601()
-        result.integrations = system.integrations
+        result.integrations = try? JSON([String: Any]())
         
         return result
     }

--- a/Sources/Segment/Utilities/Storage.swift
+++ b/Sources/Segment/Utilities/Storage.swift
@@ -239,6 +239,8 @@ extension Storage {
         if fm.fileExists(atPath: storeFile.path) == false {
             start(file: storeFile)
             newFile = true
+        } else if fileHandle == nil {
+            fileHandle = try? FileHandle(forWritingTo: file)
         }
         
         // Verify file size isn't too large

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -86,7 +86,7 @@ final class Analytics_Tests: XCTestCase {
         UserDefaults.standard.removePersistentDomain(forName: "com.segment.storage.test")
         
         let expectation = XCTestExpectation(description: "MyDestination Expectation")
-        let myDestination = MyDestination {
+        let myDestination = MyDestination(disabled: true) {
             expectation.fulfill()
             return true
         }

--- a/Tests/Segment-Tests/Support/TestUtilities.swift
+++ b/Tests/Segment-Tests/Support/TestUtilities.swift
@@ -75,15 +75,21 @@ class MyDestination: DestinationPlugin {
     var analytics: Analytics?
     let trackCompletion: (() -> Bool)?
     
-    init(trackCompletion: (() -> Bool)? = nil) {
+    let disabled: Bool
+    
+    init(disabled: Bool = false, trackCompletion: (() -> Bool)? = nil) {
         self.key = "MyDestination"
         self.type = .destination
         self.timeline = Timeline()
         self.trackCompletion = trackCompletion
+        self.disabled = disabled
     }
     
     func update(settings: Settings, type: UpdateType) {
-        //
+        if disabled == false {
+            // add ourselves to the settings
+            analytics?.manuallyEnableDestination(plugin: self)
+        }
     }
     
     func track(event: TrackEvent) -> TrackEvent? {

--- a/Tests/Segment-Tests/Timeline_Tests.swift
+++ b/Tests/Segment-Tests/Timeline_Tests.swift
@@ -26,17 +26,7 @@ class Timeline_Tests: XCTestCase {
             return true
         }
 
-        // Do this to force enable the destination
-        var settings = Settings(writeKey: "test")
-        if let existing = settings.integrations?.dictionaryValue {
-            var newIntegrations = existing
-            newIntegrations[firstDestination.key] = true
-            settings.integrations = try! JSON(newIntegrations)
-        }
         let configuration = Configuration(writeKey: "test")
-        configuration.defaultSettings(settings)
-
-        
         let analytics = Analytics(configuration: configuration)
 
         analytics.add(plugin: firstDestination)


### PR DESCRIPTION
- Modified timeline to determine enablement by a combination of event data as well as settings data.
- Added method `hasIntegrationSettings`.
- Removed confusing state entries re integrations vs. settings for integrations.
- Modified Segment destination to construct integration object as it's being sent to segment rather than try to do it beforehand.