### PR TITLE
fix: screen event needs to be setup properly

### DIFF
--- a/Sources/Segment/Events.swift
+++ b/Sources/Segment/Events.swift
@@ -188,7 +188,7 @@ extension Analytics {
                 exceptionFailure("Could not parse properties.")
             }
         }
-        process(event: event)
+        process(incomingEvent: event)
     }
     
     /// Associate a user with a group such as a company, organization, project, etc.


### PR DESCRIPTION
The screen call would be calling to the wrong process method so that the event would not be set up correctly. In my case the `integrations` were not setup correctly so when I used `enableCloudIntegration` on the rawEvent it would throw an error complaining that integrations is not a dictionary.

I ran all the tests and they are passing. I did not find any tests specifically for this behaviour and was not familiar enough with the codebase to do that myself. 