### PR TITLE
Call correct process method in Group.

### DIFF
--- a/Sources/Segment/Events.swift
+++ b/Sources/Segment/Events.swift
@@ -205,6 +205,6 @@ extension Analytics {
                 exceptionFailure("Could not parse traits.")
             }
         }
-        process(event: event)
+        process(incomingEvent: event)
     }
 }

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -320,7 +320,7 @@ final class Analytics_Tests: XCTestCase {
         
         let newBatchCount = analytics.storage.eventFiles(includeUnfinished: true).count
         // 1 new temp file
-        XCTAssertTrue(newBatchCount == currentBatchCount + 1)
+        XCTAssertTrue(newBatchCount == currentBatchCount + 1, "New Count (\(newBatchCount)) should be \(currentBatchCount) + 1")
     }
     
     func testVersion() {

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -319,8 +319,8 @@ final class Analytics_Tests: XCTestCase {
         analytics.track(name: "test")
         
         let newBatchCount = analytics.storage.eventFiles(includeUnfinished: true).count
-        // 1 new temp file, and 1 new finished file.
-        XCTAssertTrue(newBatchCount == currentBatchCount + 2)
+        // 1 new temp file
+        XCTAssertTrue(newBatchCount == currentBatchCount + 1)
     }
     
     func testVersion() {


### PR DESCRIPTION
group was calling process(event: ) instead of process(incomingEvent: ) like the rest of the event methods.