### PR TITLE
use cache directory instead of documents

### DIFF
--- a/Sources/Segment/Utilities/Storage.swift
+++ b/Sources/Segment/Utilities/Storage.swift
@@ -182,7 +182,7 @@ extension Storage {
     }
     
     private func eventStorageDirectory() -> URL {
-        let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        let urls = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
         let docURL = urls[0]
         let segmentURL = docURL.appendingPathComponent("segment/\(writeKey)/")
         // try to create it, will fail if already exists, nbd.


### PR DESCRIPTION
i kept seeing an error that tvOS was having trouble writing to anything inside the Documents directory. 

it sounds like for tvOS, they suggest using Cache for anything you need:
https://developer.apple.com/library/archive/documentation/General/Conceptual/AppleTV_PG/index.html#//apple_ref/doc/uid/TP40015241
https://developer.apple.com/forums/thread/89008

