### PR TITLE
Use different path for tvOS storage.

### DIFF
--- a/Sources/Segment/Utilities/Storage.swift
+++ b/Sources/Segment/Utilities/Storage.swift
@@ -182,7 +182,13 @@ extension Storage {
     }
     
     private func eventStorageDirectory() -> URL {
-        let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        #if os(tvOS)
+        let searchPathDirectory = FileManager.SearchPathDirectory.documentDirectory
+        #else
+        let searchPathDirectory = FileManager.SearchPathDirectory.cachesDirectory
+        #endif
+        
+        let urls = FileManager.default.urls(for: searchPathDirectory, in: .userDomainMask)
         let docURL = urls[0]
         let segmentURL = docURL.appendingPathComponent("segment/\(writeKey)/")
         // try to create it, will fail if already exists, nbd.

--- a/Sources/Segment/Utilities/Storage.swift
+++ b/Sources/Segment/Utilities/Storage.swift
@@ -183,9 +183,9 @@ extension Storage {
     
     private func eventStorageDirectory() -> URL {
         #if os(tvOS)
-        let searchPathDirectory = FileManager.SearchPathDirectory.documentDirectory
-        #else
         let searchPathDirectory = FileManager.SearchPathDirectory.cachesDirectory
+        #else
+        let searchPathDirectory = FileManager.SearchPathDirectory.documentDirectory
         #endif
         
         let urls = FileManager.default.urls(for: searchPathDirectory, in: .userDomainMask)


### PR DESCRIPTION
Alternate way of accepting PR #98.  We may have to make further OS distinctions in the future.