### PR TITLE
on macOS, like on tvOS use the caches folder

### DIFF
--- a/Sources/Segment/Utilities/Storage.swift
+++ b/Sources/Segment/Utilities/Storage.swift
@@ -182,7 +182,7 @@ extension Storage {
     }
     
     private func eventStorageDirectory() -> URL {
-        #if os(tvOS)
+        #if os(tvOS) || os(macOS)
         let searchPathDirectory = FileManager.SearchPathDirectory.cachesDirectory
         #else
         let searchPathDirectory = FileManager.SearchPathDirectory.documentDirectory


### PR DESCRIPTION
On macOS, if the app is not sandboxed, the folder for events storage ends up in the user's `~/Documents/` directory, which potentially gets synced via iCloud Documents.

Let's also use the caches directory (`~/Library/Caches/`) on macOS, same as tvOS.

(I had a previous patch which moved all platforms to caches directory, given the documents folder on iOS might also be synced across devices. WDYT?)