### PR TITLE
Fix for app being terminated due to lingering bg tasks.

### DIFF
--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
@@ -191,7 +191,7 @@ extension SegmentDestination.UploadTaskInfo {
         
         if let application = UIApplication.safeShared {
             let taskIdentifier = application.beginBackgroundTask { [self] in
-                self.task.suspend()
+                self.task.cancel()
                 self.cleanup?()
             }
             self.taskID = taskIdentifier.rawValue

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -128,6 +128,10 @@ public class SegmentDestination: DestinationPlugin {
                     }
                     
                     analytics.log(message: "Processed: \(url.lastPathComponent)")
+                    // the upload we have here has just finished.
+                    // make sure it gets removed and it's cleanup() called rather
+                    // than waiting on the next flush to come around.
+                    self.cleanupUploads()
                 }
                 // we have a legit upload in progress now, so add it to our list.
                 if let upload = uploadTask {

--- a/Sources/Segment/Utilities/HTTPClient.swift
+++ b/Sources/Segment/Utilities/HTTPClient.swift
@@ -168,10 +168,11 @@ extension HTTPClient {
         configuration.allowsCellularAccess = true
         configuration.timeoutIntervalForResource = 30
         configuration.timeoutIntervalForRequest = 60
+        configuration.httpMaximumConnectionsPerHost = 2
         configuration.httpAdditionalHeaders = ["Content-Type": "application/json; charset=utf-8",
                                                "Authorization": "Basic \(Self.authorizationHeaderForWriteKey(writeKey))",
                                                "User-Agent": "analytics-ios/\(Analytics.version())"]
-        let session = URLSession.init(configuration: configuration, delegate: nil, delegateQueue: nil)
+        let session = URLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
         return session
     }
 }


### PR DESCRIPTION
Addresses issue #54 

- Cancels tasks if we run over rather than just suspending them.
- Perform upload task cleanup as a task finishes rather than waiting for flush() to come around again.
- Sets maximum connections to host to 2, rather than the default of 6 to ensure we're not filling up the entire network.