### PR TITLE
Fix Firebase Plugin Import

### DIFF
--- a/Examples/destination_plugins/FirebaseDestination.swift
+++ b/Examples/destination_plugins/FirebaseDestination.swift
@@ -4,14 +4,12 @@
 //
 //  Created by Cody Garvin on 6/3/21.
 //
-
 // NOTE: You can see this plugin in use in the DestinationsExample application.
 //
 // This plugin is NOT SUPPORTED by Segment.  It is here merely as an example,
 // and for your convenience should you find it useful.
 //
 // Firebase SPM package can be found here: https://github.com/firebase/firebase-ios-sdk
-
 // MIT License
 //
 // Copyright (c) 2021 Segment
@@ -33,10 +31,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-
 import Foundation
 import Segment
-import FirebaseCore
+import Firebase
 import FirebaseAnalytics
 
 /**
@@ -114,7 +111,6 @@ class FirebaseDestination: DestinationPlugin {
 }
 
 // MARK: - Support methods
-
 extension FirebaseDestination {
     
     // Maps Segment spec to Firebase constant

--- a/Examples/destination_plugins/FirebaseDestination.swift
+++ b/Examples/destination_plugins/FirebaseDestination.swift
@@ -4,12 +4,14 @@
 //
 //  Created by Cody Garvin on 6/3/21.
 //
+
 // NOTE: You can see this plugin in use in the DestinationsExample application.
 //
 // This plugin is NOT SUPPORTED by Segment.  It is here merely as an example,
 // and for your convenience should you find it useful.
 //
 // Firebase SPM package can be found here: https://github.com/firebase/firebase-ios-sdk
+
 // MIT License
 //
 // Copyright (c) 2021 Segment
@@ -31,6 +33,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
 import Foundation
 import Segment
 import Firebase
@@ -111,6 +114,7 @@ class FirebaseDestination: DestinationPlugin {
 }
 
 // MARK: - Support methods
+
 extension FirebaseDestination {
     
     // Maps Segment spec to Firebase constant


### PR DESCRIPTION
As per Firebase's documentation here: https://firebase.google.com/docs/ios/setup#initialize-firebase

The `FirebaseCore` library is no longer needed and instead the `Firebase` library is used.