### PR TITLE
Fix cleanup handler not called on background task expiration due to struct being captured before assignment

### DIFF
--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
@@ -190,14 +190,15 @@ extension SegmentDestination.UploadTaskInfo {
         self.task = task
         
         if let application = UIApplication.safeShared {
-            let taskIdentifier = application.beginBackgroundTask { [self] in
-                self.task.cancel()
-                self.cleanup?()
+            var taskIdentifier: UIBackgroundTaskIdentifier = .invalid
+            taskIdentifier = application.beginBackgroundTask {
+                task.cancel()
+                application.endBackgroundTask(taskIdentifier)
             }
             self.taskID = taskIdentifier.rawValue
             
-            self.cleanup = { [self] in
-                application.endBackgroundTask(UIBackgroundTaskIdentifier(rawValue: self.taskID))
+            self.cleanup = {
+                application.endBackgroundTask(taskIdentifier)
             }
         }
     }


### PR DESCRIPTION
We were encountering this issue:
https://github.com/segmentio/analytics-swift/issues/54

The PR for the issue (https://github.com/segmentio/analytics-swift/pull/111) does prevent background crashes due to the upload task now completing on time

However, there is still an issue; `application.endBackgroundTask` is not called for tasks that do happen to expire in the background

`UploadTaskInfo` as a value type is captured by `beginBackgroundTask` before the `cleanup` handler is assigned. You can see the issue by running version 1.0.6 where tasks expired often and set the breakpoint as seen in the attached screenshot

My fix is to no longer capture self in either closure.

<img width="1060" alt="Screen Shot 2022-02-12 at 4 31 44 PM" src="https://user-images.githubusercontent.com/2341305/153756071-69b503c0-5845-44a9-8c95-caca47c81914.png">

