### PR TITLE
Fix issue where cascading network timeouts compound on each other

### DIFF
--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -120,20 +120,27 @@ public class SegmentDestination: DestinationPlugin {
             for url in data {
                 analytics.log(message: "Processing Batch:\n\(url.lastPathComponent)")
                 
-                let uploadTask = httpClient.startBatchUpload(writeKey: analytics.configuration.values.writeKey, batch: url) { (result) in
+                let uploadTask = httpClient.startBatchUpload(writeKey: analytics.configuration.values.writeKey, batch: url) { [weak self] (result) in
                     switch result {
                         case .success(_):
                             storage.remove(file: url)
-                            self.cleanupUploads()
-                        default:
-                            analytics.logFlush()
+                            analytics.log(message: "Processed: \(url.lastPathComponent)")
+                        case .failure(let e):
+                            analytics.log(message: "Failed to process: \(url.lastPathComponent), \(e)")
+                            if e.connectivityError {
+                                self?.flushTimer?.suspend()
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 300) { [weak self] in
+                                    self?.flushTimer?.resume()
+                                }
+                            }
                     }
                     
-                    analytics.log(message: "Processed: \(url.lastPathComponent)")
+                    analytics.logFlush()
+
                     // the upload we have here has just finished.
                     // make sure it gets removed and it's cleanup() called rather
                     // than waiting on the next flush to come around.
-                    self.cleanupUploads()
+                    self?.cleanupUploads()
                 }
                 // we have a legit upload in progress now, so add it to our list.
                 if let upload = uploadTask {

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -128,6 +128,8 @@ public class SegmentDestination: DestinationPlugin {
                         case .failure(let e):
                             analytics.log(message: "Failed to process: \(url.lastPathComponent), \(e)")
                             if e.connectivityError {
+                                // In the event of a connectivity error, suspend
+                                // the flush timer for 5 minutes, and then resume it.
                                 self?.flushTimer?.suspend()
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 300) { [weak self] in
                                     self?.flushTimer?.resume()

--- a/Sources/Segment/Utilities/HTTPClient.swift
+++ b/Sources/Segment/Utilities/HTTPClient.swift
@@ -16,6 +16,21 @@ enum HTTPClientErrors: Error {
     case statusCode(code: Int)
 }
 
+extension Error {
+    internal var connectivityError: Bool {
+        guard let urlError = self as? URLError else { return false }
+        
+        switch urlError.code {
+        case .timedOut:
+            fallthrough
+        case .notConnectedToInternet:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 public class HTTPClient {
     private static let defaultAPIHost = "api.segment.io/v1"
     private static let defaultCDNHost = "cdn-settings.segment.com/v1"


### PR DESCRIPTION
Fixes issue #152 

It was observed that when network traffic is blocked that outbound requests are timing out after 60 seconds, however the flush interval has a default of 30 seconds.  This would result in a cascading set of outbound network requests that would all fail.

This change makes it such that in the case where connectivity is unavailable, we pause the flush timer for 5 minutes before attempting again.