### PR TITLE
Fix nil value parsing

### DIFF
--- a/Sources/Segment/Utilities/JSON.swift
+++ b/Sources/Segment/Utilities/JSON.swift
@@ -51,7 +51,7 @@ public enum JSON: Equatable {
             }
             
         // handle swift types
-        case nil:
+        case Optional<Any>.none:
             self = .null
         case let url as URL:
             self = .string(url.absoluteString)

--- a/Tests/Segment-Tests/JSON_Tests.swift
+++ b/Tests/Segment-Tests/JSON_Tests.swift
@@ -53,7 +53,7 @@ class JSONTests: XCTestCase {
     }
     
     func testJSONNil() throws {
-        let traits = try JSON(["type": NSNull(), "preferences": ["bwack"]])
+        let traits = try JSON(["type": NSNull(), "preferences": ["bwack"], "key": nil])
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
         


### PR DESCRIPTION
Comparing `Any` to `nil` always returns false, so when nil is passed as a value in traits you will always receive a `nonJSONType` error