### PR TITLE
feat: add application foregrounded events to iOS and macOS

### DIFF
--- a/Sources/Segment/Plugins/Platforms/Mac/macOSLifecycleEvents.swift
+++ b/Sources/Segment/Plugins/Platforms/Mac/macOSLifecycleEvents.swift
@@ -98,6 +98,8 @@ class macOSLifecycleEvents: PlatformPlugin, macOSLifecycle {
             return
         }
         
+        analytics?.track(name: "Application Foregrounded")
+        
         // Lets check if we skipped application:didFinishLaunchingWithOptions,
         // if so, lets call it.
         if didFinishLaunching == false {

--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
@@ -94,6 +94,8 @@ class iOSLifecycleEvents: PlatformPlugin, iOSLifecycle {
             return
         }
         
+        analytics?.track(name: "Application Foregrounded")
+        
         // Lets check if we skipped application:didFinishLaunchingWithOptions,
         // if so, lets call it.
         if didFinishLaunching == false {


### PR DESCRIPTION
This PR adds an "Application Foreground" event to the iOS and macOS lifecycle handlers which is tracked on every call of `applicationDidBecomeActive`. This is equivalent to the "Application Backgrounded" event which is tracked on every call of `applicationDidResignActive`.

Closes #172.