### PR TITLE
hardcode `macOS` value in context.os.name

### DIFF
--- a/Sources/Segment/Events.swift
+++ b/Sources/Segment/Events.swift
@@ -37,7 +37,8 @@ extension Analytics {
     /// - Parameters:
     ///   - userId: A database ID for this user. If you don't have a userId
     ///     but want to record traits, just pass traits into the event and they will be associated
-    ///     with the anonymousId of that user. For more information on how we
+    ///     with the anonymousId of that user.  In the case when user logs out, make sure to
+    ///     call ``reset()`` to clear the user's identity info. For more information on how we
     ///     generate the UUID and Apple's policies on IDs, see
     ///      https://segment.io/libraries/ios#ids
     /// - traits: A dictionary of traits you know about the user. Things like: email, name, plan, etc.
@@ -136,7 +137,8 @@ extension Analytics {
     /// - Parameters:
     ///   - userId: A database ID for this user. If you don't have a userId
     ///     but want to record traits, just pass traits into the event and they will be associated
-    ///     with the anonymousId of that user. For more information on how we
+    ///     with the anonymousId of that user.  In the case when user logs out, make sure to
+    ///     call ``reset()`` to clear the user's identity info. For more information on how we
     ///     generate the UUID and Apple's policies on IDs, see
     ///      https://segment.io/libraries/ios#ids
     ///   - properties: A dictionary of traits you know about the user. Things like: email, name, plan, etc.
@@ -157,7 +159,8 @@ extension Analytics {
     /// - Parameters:
     ///   - userId: A database ID for this user. If you don't have a userId
     ///     but want to record traits, just pass traits into the event and they will be associated
-    ///     with the anonymousId of that user. For more information on how we
+    ///     with the anonymousId of that user.  In the case when user logs out, make sure to
+    ///     call ``reset()`` to clear the user's identity info. For more information on how we
     ///     generate the UUID and Apple's policies on IDs, see
     ///      https://segment.io/libraries/ios#ids
     ///   - traits: A dictionary of traits you know about the user. Things like: email, name, plan, etc.

--- a/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
@@ -222,7 +222,7 @@ internal class MacOSVendorSystem: VendorSystem {
     }
     
     override var systemName: String {
-        return device.operatingSystemVersionString
+        return "macOS"
     }
     
     override var systemVersion: String {


### PR DESCRIPTION
- hardcodes `macOS` in `context.os.name`
- adds reset() callout in identify docs