### PR TITLE
Fix to append rather than overwrite data in existing files

### DIFF
--- a/Sources/Segment/Utilities/OutputFileStream.swift
+++ b/Sources/Segment/Utilities/OutputFileStream.swift
@@ -53,6 +53,11 @@ internal class OutputFileStream {
         if fileHandle != nil { return }
         do {
             fileHandle = try FileHandle(forWritingTo: fileURL)
+            if #available(iOS 13.4, *) {
+                _ = try? fileHandle?.seekToEnd()
+            } else {
+                try? fileHandle?.seek(toOffset: .max)
+            }
         } catch {
             throw OutputStreamError.unableToOpen(fileURL.path)
         }

--- a/Sources/Segment/Utilities/OutputFileStream.swift
+++ b/Sources/Segment/Utilities/OutputFileStream.swift
@@ -53,10 +53,13 @@ internal class OutputFileStream {
         if fileHandle != nil { return }
         do {
             fileHandle = try FileHandle(forWritingTo: fileURL)
-            if #available(iOS 13.4, *) {
+            if #available(iOS 13.4, macOS 10.15.4, tvOS 13.4, *) {
                 _ = try? fileHandle?.seekToEnd()
-            } else {
+            } else if #available(tvOS 13.0, *) {
                 try? fileHandle?.seek(toOffset: .max)
+            } else {
+                // unsupported
+                throw OutputStreamError.unableToOpen(fileURL.path)
             }
         } catch {
             throw OutputStreamError.unableToOpen(fileURL.path)


### PR DESCRIPTION
The existing code will result in malformed JSON being sent to the server because of partial events overwriting the start of existing files.  This fix will ensure we always append to a pre-existing file.