### PR TITLE
Removed trackDeepLinks from configuration

### DIFF
--- a/Sources/Segment/Configuration.swift
+++ b/Sources/Segment/Configuration.swift
@@ -17,7 +17,6 @@ public class Configuration {
         var writeKey: String
         var application: Any? = nil
         var trackApplicationLifecycleEvents: Bool = true
-        var trackDeeplinks: Bool = true
         var flushAt: Int = 20
         var flushInterval: TimeInterval = 30
         var defaultSettings: Settings? = nil
@@ -48,12 +47,6 @@ public extension Configuration {
     @discardableResult
     func trackApplicationLifecycleEvents(_ enabled: Bool) -> Configuration {
         values.trackApplicationLifecycleEvents = enabled
-        return self
-    }
-    
-    @discardableResult
-    func trackDeeplinks(_ enabled: Bool) -> Configuration {
-        values.trackDeeplinks = enabled
         return self
     }
     

--- a/Sources/Segment/ObjC/ObjCAnalytics.swift
+++ b/Sources/Segment/ObjC/ObjCAnalytics.swift
@@ -167,6 +167,11 @@ extension ObjCAnalytics {
     }
     
     @objc
+    public func openURL(_ url: URL, options: [String: Any] = [:]) {
+        analytics.openURL(url, options: options)
+    }
+    
+    @objc
     public func version() -> String {
         return analytics.version()
     }

--- a/Sources/Segment/ObjC/ObjCConfiguration.swift
+++ b/Sources/Segment/ObjC/ObjCConfiguration.swift
@@ -34,16 +34,6 @@ public class ObjCConfiguration: NSObject {
     }
     
     @objc
-    public var trackDeeplinks: Bool {
-        get {
-            return configuration.values.trackDeeplinks
-        }
-        set(value) {
-            configuration.trackDeeplinks(value)
-        }
-    }
-    
-    @objc
     public var flushAt: Int {
         get {
             return configuration.values.flushAt


### PR DESCRIPTION
- Fixes #194 
- Removes trackDeepLinks from the swift and objc configuration objects
- Adds openURL to the objc wrapper.