### PR TITLE
Handle `Set` properly when given to JSON instance.

### DIFF
--- a/Sources/Segment/Utilities/JSON.swift
+++ b/Sources/Segment/Utilities/JSON.swift
@@ -59,7 +59,7 @@ public enum JSON: Equatable {
             self = .string(string)
         case let bool as Bool:
             self = .bool(bool)
-        case let array as [Any]:
+        case let array as any Collection:
             self = .array(try array.map(JSON.init))
         case let object as [String: Any]:
             self = .object(try object.mapValues(JSON.init))

--- a/Sources/Segment/Utilities/JSON.swift
+++ b/Sources/Segment/Utilities/JSON.swift
@@ -59,7 +59,9 @@ public enum JSON: Equatable {
             self = .string(string)
         case let bool as Bool:
             self = .bool(bool)
-        case let array as any Collection:
+        case let aSet as Set<AnyHashable>:
+            self = .array(try aSet.map(JSON.init))
+        case let array as Array<Any>:
             self = .array(try array.map(JSON.init))
         case let object as [String: Any]:
             self = .object(try object.mapValues(JSON.init))

--- a/Tests/Segment-Tests/JSON_Tests.swift
+++ b/Tests/Segment-Tests/JSON_Tests.swift
@@ -52,6 +52,16 @@ class JSONTests: XCTestCase {
         }
     }
     
+    func testJSONCollectionTypes() throws {
+        let testSet: Set = ["1", "2", "3"]
+        let traits = try! JSON(["type": NSNull(), "preferences": ["bwack"], "key": testSet])
+        let jsonSet = traits["key"]
+        XCTAssertNotNil(jsonSet)
+        let array = jsonSet!.arrayValue!
+        XCTAssertNotNil(array)
+        XCTAssertEqual(array.count, 3)
+    }
+    
     func testJSONNil() throws {
         let traits = try JSON(["type": NSNull(), "preferences": ["bwack"], "key": nil])
         let encoder = JSONEncoder()


### PR DESCRIPTION
- Fixes #198 .
- Adds support for Set as a JSON type.
- Added test.