### PR TITLE
Use EventPlugin in ObjcDestinationShim

### DIFF
--- a/Sources/Segment/ObjC/ObjCDestinationSupport.swift
+++ b/Sources/Segment/ObjC/ObjCDestinationSupport.swift
@@ -13,7 +13,7 @@ import Foundation
 public protocol ObjCDestination {}
 
 public protocol ObjCDestinationShim {
-    func instance() -> DestinationPlugin
+    func instance() -> EventPlugin
 }
 
 // NOTE: Destination plugins need something similar to the following to work


### PR DESCRIPTION
- Modified ObjcDestinationShim to use EventPlugin instead of DestinationPlugin
- Allows for enrichment style destinations such as Amplitude