### PR TITLE
Example Network Blocker flush policy

### DIFF
--- a/Examples/apps/MacExample/MacExample.xcodeproj/project.pbxproj
+++ b/Examples/apps/MacExample/MacExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		464B2D5C29F9DF3C00471ABF /* NetBlockerFlushPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464B2D5B29F9DF3C00471ABF /* NetBlockerFlushPolicy.swift */; };
 		4663C738267A926B00ADDD1A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4663C737267A926B00ADDD1A /* AppDelegate.swift */; };
 		4663C73A267A926B00ADDD1A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4663C739267A926B00ADDD1A /* ViewController.swift */; };
 		4663C73C267A926C00ADDD1A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4663C73B267A926C00ADDD1A /* Assets.xcassets */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		464B2D5B29F9DF3C00471ABF /* NetBlockerFlushPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetBlockerFlushPolicy.swift; path = ../../../tasks/NetBlockerFlushPolicy.swift; sourceTree = "<group>"; };
 		4663C734267A926B00ADDD1A /* MacExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MacExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4663C737267A926B00ADDD1A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		4663C739267A926B00ADDD1A /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -59,6 +61,7 @@
 		4663C736267A926B00ADDD1A /* MacExample */ = {
 			isa = PBXGroup;
 			children = (
+				464B2D5B29F9DF3C00471ABF /* NetBlockerFlushPolicy.swift */,
 				4663C737267A926B00ADDD1A /* AppDelegate.swift */,
 				4663C739267A926B00ADDD1A /* ViewController.swift */,
 				4663C73B267A926C00ADDD1A /* Assets.xcassets */,
@@ -157,6 +160,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4663C73A267A926B00ADDD1A /* ViewController.swift in Sources */,
+				464B2D5C29F9DF3C00471ABF /* NetBlockerFlushPolicy.swift in Sources */,
 				4663C738267A926B00ADDD1A /* AppDelegate.swift in Sources */,
 				46E73DA926F53C570021042C /* NotificationTracking.swift in Sources */,
 			);

--- a/Examples/apps/MacExample/MacExample/AppDelegate.swift
+++ b/Examples/apps/MacExample/MacExample/AppDelegate.swift
@@ -12,7 +12,7 @@ import Segment
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     var analytics: Analytics? = nil
-
+    let blockerFlushPolicy = NetBlockerFlushPolicy()
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
@@ -20,8 +20,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let configuration = Configuration(writeKey: "<WRITE KEY>")
             .trackApplicationLifecycleEvents(true)
             .flushInterval(10)
+            .flushAt(1)
+            .errorHandler { error in
+                NetBlockerFlushPolicy.networkBlockedHandler(error: error, blockerPolicy: self.blockerFlushPolicy)
+            }
         
         analytics = Analytics(configuration: configuration)
+        analytics?.add(flushPolicy: blockerFlushPolicy)
+        
+        Timer.scheduledTimer(withTimeInterval: 5, repeats: true, block: { _ in
+            self.analytics?.track(name: "test little snitch")
+        })
+        
         //analytics?.add(plugin: NotificationTracking())
     }
 

--- a/Examples/tasks/NetBlockerFlushPolicy.swift
+++ b/Examples/tasks/NetBlockerFlushPolicy.swift
@@ -1,0 +1,110 @@
+//
+//  NetBlockerFlushPolicy.swift
+//  
+//
+//  Created by Brandon Sneed on 4/26/23.
+//
+
+import Foundation
+
+// NOTE: You can see this task in use in the MacExample application.
+
+// MIT License
+//
+// Copyright (c) 2023 Segment
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Segment
+
+public class NetBlockerFlushPolicy: FlushPolicy {
+    public var type = PluginType.utility
+    public weak var analytics: Segment.Analytics?
+    
+    static func networkBlockedHandler(error: Error, blockerPolicy: NetBlockerFlushPolicy) {
+        switch error {
+        case AnalyticsError.networkUnknown(let error):
+            if let e = error as? URLError {
+                if e.code == URLError.networkConnectionLost {
+                    // Little Snitch might be running..
+                    // lets disable analytics for now.
+                    blockerPolicy.analytics?.enabled = false
+                    print("The network appears to be blocked.  Disabling Analytics.")
+                }
+            }
+        default:
+            break
+        }
+    }
+    
+    public func configure(analytics: Segment.Analytics) {
+        // if we've already been configured, exit.
+        guard self.analytics == nil else { return }
+        
+        self.analytics = analytics
+        // add our utility plugin portion of our policy ...
+        // that way we can try to enable analytics when the app comes back to the foreground.
+        self.analytics?.add(plugin: self)
+    }
+    
+    public func shouldFlush() -> Bool {
+        // if we're enabled, then flush.  if we don't know if we're enabled
+        // it's probably because our analytics pointer became nil somehow, so
+        // to prevent unexpected catastrophe, assume true.
+        return self.analytics?.enabled ?? true
+    }
+    
+    public func updateState(event: Segment.RawEvent) {
+        // do nothing
+    }
+    
+    public func reset() {
+        // if we're told to reset.. lets try again.
+        analytics?.enabled = true
+    }
+}
+
+extension NetBlockerFlushPolicy: UtilityPlugin {
+    // we can be a utility plugin as well to get lifecycle events to act on
+    // see `type` defined in the main class above.
+}
+
+#if os(macOS)
+extension NetBlockerFlushPolicy: macOSLifecycle {
+    public func applicationDidBecomeActive() {
+        // try to turn back on analytics and see if it's allowed ... if net is still
+        // blocked, analytics will be disabled again.
+        analytics?.enabled = true
+        print("Turning analytics back on ...")
+    }
+}
+#endif
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+import UIKit
+extension NetBlockerFlushPolicy: iOSLifecycle {
+    public func applicationDidBecomeActive(application: UIApplication?) {
+        // try to turn back on analytics and see if it's allowed ... if net is still
+        // blocked, analytics will be disabled again.
+        analytics?.enabled = true
+        print("Turning analytics back on ...")
+    }
+}
+#endif

--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -168,6 +168,9 @@ extension Analytics {
     /// Tells this instance of Analytics to flush any queued events up to Segment.com.  This command will also
     /// be sent to each plugin present in the system.
     public func flush() {
+        // only flush if we're enabled.
+        guard enabled == true else { return }
+        
         apply { plugin in
             if let p = plugin as? EventPlugin {
                 p.flush()

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -116,6 +116,9 @@ public class SegmentDestination: DestinationPlugin, Subscriber {
         guard let storage = self.storage else { return }
         guard let analytics = self.analytics else { return }
         guard let httpClient = self.httpClient else { return }
+        
+        // don't flush if analytics is disabled.
+        guard analytics.enabled == true else { return }
 
         // Read events from file system
         guard let data = storage.read(Storage.Constants.events) else { return }


### PR DESCRIPTION
- Added an example Network Blocker flush policy.
- Report internal error at low level request failure.
- Disable flush() when analytics is disabled.