### PR TITLE
feat: Fallback to `CFBundleName` if `CFBundleDisplayName` not available

### DIFF
--- a/Sources/Segment/Plugins/Context.swift
+++ b/Sources/Segment/Plugins/Context.swift
@@ -73,7 +73,7 @@ public class Context: PlatformPlugin {
         }
         if app.count != 0 {
             staticContext["app"] = [
-                "name": app["CFBundleDisplayName"] ?? "",
+                "name": app["CFBundleDisplayName"] ?? app["CFBundleName"] ?? "",
                 "version": app["CFBundleShortVersionString"] ?? "",
                 "build": app["CFBundleVersion"] ?? "",
                 "namespace": Bundle.main.bundleIdentifier ?? ""


### PR DESCRIPTION
Not all apps include a `CFBundleDisplayName` in the `info.plist`. In this case the `context.app.name` is empty. This resolves by falling back to using `CFBundleName` if `CFBundleDisplayName` is not present.

See: https://github.com/segmentio/analytics-swift/issues/243