### PR TITLE
Update Flush policies

### DIFF
--- a/Sources/Segment/Utilities/Policies/CountBasedFlushPolicy.swift
+++ b/Sources/Segment/Utilities/Policies/CountBasedFlushPolicy.swift
@@ -12,9 +12,9 @@ public class CountBasedFlushPolicy: FlushPolicy {
     internal var desiredCount: Int?
     @Atomic internal var count: Int = 0
     
-    init() { }
+    public init() { }
     
-    init(count: Int) {
+    public init(count: Int) {
         desiredCount = count
     }
     

--- a/Sources/Segment/Utilities/Policies/IntervalBasedFlushPolicy.swift
+++ b/Sources/Segment/Utilities/Policies/IntervalBasedFlushPolicy.swift
@@ -15,9 +15,9 @@ public class IntervalBasedFlushPolicy: FlushPolicy,
     internal var desiredInterval: TimeInterval?
     internal var flushTimer: QueueTimer? = nil
     
-    init() { }
+    public init() { }
     
-    init(interval: TimeInterval) {
+    public init(interval: TimeInterval) {
         desiredInterval = interval
     }
     

--- a/Tests/Segment-Tests/FlushPolicy_Tests.swift
+++ b/Tests/Segment-Tests/FlushPolicy_Tests.swift
@@ -129,7 +129,7 @@ class FlushPolicyTests: XCTestCase {
         // make sure storage has no old events
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
         
-        let intervalFlush = IntervalBasedFlushPolicy(interval: 4)
+        let intervalFlush = IntervalBasedFlushPolicy(interval: 2)
         analytics.add(flushPolicy: intervalFlush)
         
         waitUntilStarted(analytics: analytics)
@@ -137,8 +137,8 @@ class FlushPolicyTests: XCTestCase {
         
         XCTAssertTrue(analytics.hasUnsentEvents)
         
-        // sleep for 5 seconds for 4 second flush policy
-        RunLoop.main.run(until: Date.init(timeIntervalSinceNow: 6))
+        // sleep for 4 seconds for 2 second flush policy
+        RunLoop.main.run(until: Date.init(timeIntervalSinceNow: 4))
         
         XCTAssertFalse(analytics.hasUnsentEvents)
     }

--- a/Tests/Segment-Tests/FlushPolicy_Tests.swift
+++ b/Tests/Segment-Tests/FlushPolicy_Tests.swift
@@ -119,4 +119,48 @@ class FlushPolicyTests: XCTestCase {
         // we now have ONE HA HA.  TWO HA HA .. 3 ... HA HA THREE!  Items to flush!  <flys aways>
         XCTAssertTrue(countFlush.shouldFlush())
     }
+
+    func testIntervalBasedFlushPolicy() throws {
+        let analytics = Analytics(configuration: Configuration(writeKey: "intervalFlushPolicy"))
+        let intervalFlush = IntervalBasedFlushPolicy(interval: 4000)
+        analytics.add(flushPolicy: intervalFlush)
+        
+        waitUntilStarted(analytics: analytics)
+        //let event = TrackEvent(event: "blah", properties: nil)
+        analytics.track(name: "blah", properties: nil)
+        
+        let hasUnsent = analytics.hasUnsentEvents
+        XCTAssertTrue(hasUnsent)
+        
+        // sleep for 5 seconds for 4 second flush policy
+        sleep(5)
+        
+        let hasUnsent2 = analytics.hasUnsentEvents
+        XCTAssertFalse(hasUnsent2)
+    }
+    
+//      Ignore, previous test
+//    func testIntervalBasedFlushPolicy() throws {
+//        let analytics = Analytics(configuration: Configuration(writeKey: "intervalFlushPolicy"))
+//        let intervalFlush = IntervalBasedFlushPolicy(interval: 4000)
+//        analytics.add(flushPolicy: intervalFlush)
+//        
+//        waitUntilStarted(analytics: analytics)
+//        
+//        let event = TrackEvent(event: "blah", properties: nil)
+//                
+//        // 1
+//        intervalFlush.updateState(event: event)
+//        XCTAssertFalse(intervalFlush.shouldFlush())
+//
+//        let exp = expectation(description: "Test after 5 seconds")
+//        let result = XCTWaiter.wait(for: [exp], timeout: 5)
+//        
+//        if result == XCTWaiter.Result.timedOut {
+//            XCTAssertTrue(intervalFlush.shouldFlush())
+//        } else {
+//            XCTFail("Delay interrupted")
+//        }
+//    }
+    
 }

--- a/Tests/Segment-Tests/FlushPolicy_Tests.swift
+++ b/Tests/Segment-Tests/FlushPolicy_Tests.swift
@@ -122,45 +122,26 @@ class FlushPolicyTests: XCTestCase {
 
     func testIntervalBasedFlushPolicy() throws {
         let analytics = Analytics(configuration: Configuration(writeKey: "intervalFlushPolicy"))
-        let intervalFlush = IntervalBasedFlushPolicy(interval: 4000)
+        
+        //remove default flush policies
+        analytics.removeAllFlushPolicies()
+        
+        // make sure storage has no old events
+        analytics.storage.hardReset(doYouKnowHowToUseThis: true)
+        
+        let intervalFlush = IntervalBasedFlushPolicy(interval: 4)
         analytics.add(flushPolicy: intervalFlush)
         
         waitUntilStarted(analytics: analytics)
-        //let event = TrackEvent(event: "blah", properties: nil)
         analytics.track(name: "blah", properties: nil)
         
         let hasUnsent = analytics.hasUnsentEvents
         XCTAssertTrue(hasUnsent)
         
         // sleep for 5 seconds for 4 second flush policy
-        sleep(5)
+        RunLoop.main.run(until: Date.init(timeIntervalSinceNow: 5))
         
         let hasUnsent2 = analytics.hasUnsentEvents
         XCTAssertFalse(hasUnsent2)
     }
-    
-//      Ignore, previous test
-//    func testIntervalBasedFlushPolicy() throws {
-//        let analytics = Analytics(configuration: Configuration(writeKey: "intervalFlushPolicy"))
-//        let intervalFlush = IntervalBasedFlushPolicy(interval: 4000)
-//        analytics.add(flushPolicy: intervalFlush)
-//        
-//        waitUntilStarted(analytics: analytics)
-//        
-//        let event = TrackEvent(event: "blah", properties: nil)
-//                
-//        // 1
-//        intervalFlush.updateState(event: event)
-//        XCTAssertFalse(intervalFlush.shouldFlush())
-//
-//        let exp = expectation(description: "Test after 5 seconds")
-//        let result = XCTWaiter.wait(for: [exp], timeout: 5)
-//        
-//        if result == XCTWaiter.Result.timedOut {
-//            XCTAssertTrue(intervalFlush.shouldFlush())
-//        } else {
-//            XCTFail("Delay interrupted")
-//        }
-//    }
-    
 }

--- a/Tests/Segment-Tests/FlushPolicy_Tests.swift
+++ b/Tests/Segment-Tests/FlushPolicy_Tests.swift
@@ -135,13 +135,11 @@ class FlushPolicyTests: XCTestCase {
         waitUntilStarted(analytics: analytics)
         analytics.track(name: "blah", properties: nil)
         
-        let hasUnsent = analytics.hasUnsentEvents
-        XCTAssertTrue(hasUnsent)
+        XCTAssertTrue(analytics.hasUnsentEvents)
         
         // sleep for 5 seconds for 4 second flush policy
-        RunLoop.main.run(until: Date.init(timeIntervalSinceNow: 5))
+        RunLoop.main.run(until: Date.init(timeIntervalSinceNow: 6))
         
-        let hasUnsent2 = analytics.hasUnsentEvents
-        XCTAssertFalse(hasUnsent2)
+        XCTAssertFalse(analytics.hasUnsentEvents)
     }
 }


### PR DESCRIPTION
Default visibility of init method will be `internal`, add `public` prefix.

Also add test for the interval policy.