### PR TITLE
Make Segment.io flush asynchronous

### DIFF
--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -126,12 +126,12 @@ public class SegmentDestination: DestinationPlugin, Subscriber {
             // Read events from file system
             guard let data = storage.read(Storage.Constants.events) else { return }
             
-            eventCount = 0
-            cleanupUploads()
+            self.eventCount = 0
+            self.cleanupUploads()
             
             analytics.log(message: "Uploads in-progress: \(pendingUploads)")
             
-            if pendingUploads == 0 {
+            if self.pendingUploads == 0 {
                 for url in data {
                     analytics.log(message: "Processing Batch:\n\(url.lastPathComponent)")
                     
@@ -152,7 +152,7 @@ public class SegmentDestination: DestinationPlugin, Subscriber {
                     }
                     // we have a legit upload in progress now, so add it to our list.
                     if let upload = uploadTask {
-                        add(uploadTask: UploadTaskInfo(url: url, task: upload))
+                        self.add(uploadTask: UploadTaskInfo(url: url, task: upload))
                     }
                 }
             } else {

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -129,7 +129,7 @@ public class SegmentDestination: DestinationPlugin, Subscriber {
             self.eventCount = 0
             self.cleanupUploads()
             
-            analytics.log(message: "Uploads in-progress: \(pendingUploads)")
+            analytics.log(message: "Uploads in-progress: \(self.pendingUploads)")
             
             if self.pendingUploads == 0 {
                 for url in data {

--- a/Tests/Segment-Tests/JSON_Tests.swift
+++ b/Tests/Segment-Tests/JSON_Tests.swift
@@ -17,7 +17,6 @@ struct Personal: Codable {
 struct TestStruct: Codable {
     let str: String
     let bool: Bool
-    let float: Float
     let int: Int
     let uint: UInt
     let double: Double
@@ -98,7 +97,6 @@ class JSONTests: XCTestCase {
         let test = TestStruct(
             str: "hello",
             bool: true,
-            float: 3.14,
             int: -42,
             uint: 42,
             double: 1.234,
@@ -143,7 +141,6 @@ class JSONTests: XCTestCase {
         let test = TestStruct(
             str: "hello",
             bool: true,
-            float: 3.14,
             int: -42,
             uint: 42,
             double: 1.234,
@@ -160,13 +157,6 @@ class JSONTests: XCTestCase {
         
         let str = typedDict?["str"] as? String
         let bool = typedDict?["bool"] as? Bool
-        #if os(Linux)
-        // the linux implementation of Dictionary has
-        // some issues w/ type conversion to float.
-        let float = typedDict?["float"] as? Decimal
-        #else
-        let float = typedDict?["float"] as? Float
-        #endif
         let int = typedDict?["int"] as? Int
         let uint = typedDict?["uint"] as? UInt
         let double = typedDict?["double"] as? Double
@@ -176,7 +166,6 @@ class JSONTests: XCTestCase {
         
         XCTAssertEqual(str, "hello")
         XCTAssertEqual(bool, true)
-        XCTAssertEqual(float, 3.14)
         XCTAssertEqual(int, -42)
         XCTAssertEqual(uint, 42)
         XCTAssertEqual(double, 1.234)


### PR DESCRIPTION
- Make segment.io flush an asynchronous operation.
- Fixed naming convention for serial queue in segment destination.
- Fixes #257 

It's my suspicion that file IO is the slow-down when calling flush() from the main thread with a significant number of events present.  As such, in this fix async operation was done in the segment destination instead of the upper level analytics method to prevent unknowns from happening with device mode destinations.  Those device mode destinations (now or in the future) may not be as thread-safe, or have expectations about running on the main thread, etc.

A future-todo would be to make asynchronous file iO standard and remove usage of FileManager and the like.