### PR TITLE
Update package.swift for swift 5.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -20,18 +20,16 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(
-            name: "Sovran",
-            url: "https://github.com/segmentio/Sovran-Swift.git",
-            from: "1.1.0"
-        )
+        .package(url: "https://github.com/segmentio/sovran-swift.git", from: "1.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Segment",
-            dependencies: ["Sovran"]),
+            dependencies: [
+                .product(name: "Sovran", package: "sovran-swift")
+            ]),
         .testTarget(
             name: "Segment-Tests",
             dependencies: ["Segment"]),


### PR DESCRIPTION
Dependency methods changes from 5.3->5.7.  This change gets us those fixes without having to go all the way to 5.9, where github actions is having issues.