### PR TITLE
Allow configuration of custom userAgent

### DIFF
--- a/Sources/Segment/Configuration.swift
+++ b/Sources/Segment/Configuration.swift
@@ -26,6 +26,7 @@ public class Configuration {
         var requestFactory: ((URLRequest) -> URLRequest)? = nil
         var errorHandler: ((Error) -> Void)? = nil
         var flushPolicies: [FlushPolicy] = [CountBasedFlushPolicy(), IntervalBasedFlushPolicy()]
+        var userAgent: String? = nil
     }
     
     internal var values: Values
@@ -180,6 +181,12 @@ public extension Configuration {
     @discardableResult
     func flushPolicies(_ policies: [FlushPolicy]) -> Configuration {
         values.flushPolicies = policies
+        return self
+    }
+    
+    @discardableResult
+    func userAgent(_ userAgent: String) -> Configuration {
+        values.userAgent = userAgent
         return self
     }
 }

--- a/Sources/Segment/Plugins/Context.swift
+++ b/Sources/Segment/Plugins/Context.swift
@@ -148,7 +148,7 @@ public class Context: PlatformPlugin {
         // BKS: This use to be in the static section, however it was discovered that on some platforms
         // there can be a delay in retrieval.  It has to be fetched on the main thread, so we've spun it off
         // async and cache it when it comes back.
-        let userAgent = device.userAgent
+        let userAgent = analytics?.configuration.values.userAgent ?? device.userAgent
         context["userAgent"] = userAgent
 
         // other stuff?? ...


### PR DESCRIPTION
We've encountered a need to configure a custom user agent for app. This PR enables setting that with a new field in `Configuration`