### PR TITLE
Add initial visionOS support

### DIFF
--- a/Examples/other_plugins/NotificationTracking.swift
+++ b/Examples/other_plugins/NotificationTracking.swift
@@ -82,7 +82,7 @@ extension NotificationTracking: macOSLifecycle {
 
 // MARK: iOS/tvOS/Catalyst
 
-#if os(tvOS) || os(iOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
 
 import UIKit
 

--- a/Examples/other_plugins/NotificationTracking.swift
+++ b/Examples/other_plugins/NotificationTracking.swift
@@ -80,7 +80,7 @@ extension NotificationTracking: macOSLifecycle {
 #endif
 */
 
-// MARK: iOS/tvOS/Catalyst
+// MARK: iOS/tvOS/visionOS/Catalyst
 
 #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
 

--- a/Examples/tasks/NetBlockerFlushPolicy.swift
+++ b/Examples/tasks/NetBlockerFlushPolicy.swift
@@ -97,7 +97,7 @@ extension NetBlockerFlushPolicy: macOSLifecycle {
 }
 #endif
 
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
 import UIKit
 extension NetBlockerFlushPolicy: iOSLifecycle {
     public func applicationDidBecomeActive(application: UIApplication?) {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![](https://github.com/segmentio/analytics-swift/actions/workflows/swift.yml/badge.svg)
 ![](https://img.shields.io/github/license/segmentio/analytics-swift)
 
-The hassle-free way to add Segment analytics to your Swift app (iOS/tvOS/watchOS/macOS/Linux/iPadOS). Analytics helps you measure your users, product, and business. It unlocks insights into your app's funnel, core business metrics, and whether you have product-market fit.
+The hassle-free way to add Segment analytics to your Swift app (iOS/tvOS/visionOS/watchOS/macOS/Linux/iPadOS). Analytics helps you measure your users, product, and business. It unlocks insights into your app's funnel, core business metrics, and whether you have product-market fit.
 
 ## How to get started
 1. **Collect analytics data** from your app(s).

--- a/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - iOS, tvOS, Catalyst
 
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
 
 import SystemConfiguration
 import UIKit
@@ -30,6 +30,8 @@ internal class iOSVendorSystem: VendorSystem {
         return "ios"
         #elseif os(tvOS)
         return "tvos"
+        #elseif os(visionOS)
+        return "visionos"
         #elseif targetEnvironment(macCatalyst)
         return "macos"
         #else
@@ -60,8 +62,13 @@ internal class iOSVendorSystem: VendorSystem {
     }
     
     override var screenSize: ScreenSize {
+        #if os(iOS) || os(tvOS)
         let screenSize = UIScreen.main.bounds.size
         return ScreenSize(width: Double(screenSize.width), height: Double(screenSize.height))
+        #elseif os(visionOS)
+        let windowSize = UIApplication.shared.delegate?.window??.bounds.size
+        return windowSize.map { ScreenSize(width: $0.width, height: $0.height) } ?? ScreenSize(width: 1280, height: 720)
+        #endif
     }
     
     override var userAgent: String? {
@@ -310,7 +317,7 @@ internal class MacOSVendorSystem: VendorSystem {
 
 // MARK: - Reachability
 
-#if os(iOS) || os(tvOS) || os(macOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(tvOS) || os(visionOS) || os(macOS) || targetEnvironment(macCatalyst)
 
 #if os(macOS)
 import SystemConfiguration

--- a/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// MARK: - iOS, tvOS, Catalyst
+// MARK: - iOS, tvOS, visionOS, Catalyst
 
 #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
 

--- a/Sources/Segment/Plugins/Platforms/Vendors/VendorSystem.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/VendorSystem.swift
@@ -70,7 +70,7 @@ internal class VendorSystem {
     }
     
     static var current: VendorSystem = {
-        #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
         return iOSVendorSystem()
         #elseif os(macOS)
         return MacOSVendorSystem()

--- a/Sources/Segment/Plugins/Platforms/iOS/iOSDelegation.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSDelegation.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
 
 import UIKit
 

--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
 
 import UIKit
 

--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
@@ -5,7 +5,7 @@
 //  Created by Cody Garvin on 12/4/20.
 //
 
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
 
 import Foundation
 import UIKit

--- a/Sources/Segment/Startup.swift
+++ b/Sources/Segment/Startup.swift
@@ -49,7 +49,7 @@ extension Analytics: Subscriber {
 
         // setup lifecycle if desired
         if configuration.values.trackApplicationLifecycleEvents, operatingMode != .synchronous {
-            #if os(iOS) || os(tvOS)
+            #if os(iOS) || os(tvOS) || os(visionOS) || os(visionOS)
             plugins.append(iOSLifecycleEvents())
             #endif
             #if os(watchOS)
@@ -72,7 +72,7 @@ extension Analytics: Subscriber {
     }
 }
 
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
 import UIKit
 extension Analytics {
     internal func setupSettingsCheck() {

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -228,7 +228,7 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertTrue(token == "1234")
     }
     
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
     func testDeviceTokenData() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()

--- a/Tests/Segment-Tests/MemoryLeak_Tests.swift
+++ b/Tests/Segment-Tests/MemoryLeak_Tests.swift
@@ -35,7 +35,7 @@ final class MemoryLeak_Tests: XCTestCase {
         #if !os(Linux)
         let deviceToken = analytics.find(pluginType: DeviceToken.self)!
         #endif
-        #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
         let iosLifecycle = analytics.find(pluginType: iOSLifecycleEvents.self)!
         let iosMonitor = analytics.find(pluginType: iOSLifecycleMonitor.self)!
         #elseif os(watchOS)
@@ -59,7 +59,7 @@ final class MemoryLeak_Tests: XCTestCase {
         #if !os(Linux)
         analytics.remove(plugin: deviceToken)
         #endif
-        #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
         analytics.remove(plugin: iosLifecycle)
         analytics.remove(plugin: iosMonitor)
         #elseif os(watchOS)
@@ -80,7 +80,7 @@ final class MemoryLeak_Tests: XCTestCase {
         #if !os(Linux)
         checkIfLeaked(deviceToken)
         #endif
-        #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
         checkIfLeaked(iosLifecycle)
         checkIfLeaked(iosMonitor)
         #elseif os(watchOS)

--- a/Tests/Segment-Tests/iOSLifecycle_Tests.swift
+++ b/Tests/Segment-Tests/iOSLifecycle_Tests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Segment
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 final class iOSLifecycle_Tests: XCTestCase {
     
     func testInstallEventCreation() {


### PR DESCRIPTION
### What has been done?
1. Added `#if os(visionOS)` where it's needed.
2. Updated README mentioning the visionOS platform.

### How to test?
1. Using the latest Xcode Beta, select the visionOS simulator as the destination. Build should be successful.
1. Run unit tests.