### PR TITLE
Exclude PrivacyInfo.xcprivacy from swift package (silences warning)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
             name: "Segment",
             dependencies: [
                 .product(name: "Sovran", package: "sovran-swift")
-            ]),
+            ],
+            exclude: ["PrivacyInfo.xcprivacy"]),
         .testTarget(
             name: "Segment-Tests",
             dependencies: ["Segment"]),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -30,7 +30,8 @@ let package = Package(
             name: "Segment",
             dependencies: [
                 .product(name: "Sovran", package: "sovran-swift")
-            ]),
+            ],
+            exclude: ["PrivacyInfo.xcprivacy"]),
         .testTarget(
             name: "Segment-Tests",
             dependencies: ["Segment"]),


### PR DESCRIPTION
This file is only used by Xcode; Excluding it silences a warning with `swift build`.