### PR TITLE
Add Experimental Windows Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,5 +5,5 @@ end_of_line = lf
 insert_final_newline = true
 
 [*.swift]
-indent_style = tab
+indent_style = space
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.swift]
+indent_style = tab
+indent_size = 4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -55,9 +55,6 @@ jobs:
         branch: swift-5.8-release
         tag: 5.8-RELEASE
     - uses: actions/checkout@v2
-    - uses: webfactory/ssh-agent@v0.5.3
-      with:
-        ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
     - name: Build
       run: swift build
     - name: Run tests

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -62,8 +62,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: swift build
-      - name: Run tests
-        run: swift test --enable-test-discovery
+      # Testing disabled until https://github.com/segmentio/analytics-swift/issues/279 is fixed
+      # - name: Run tests
+      #   run: swift test --enable-test-discovery
 
   build_and_test_ios:
     needs: cancel_previous

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -46,19 +46,24 @@ jobs:
     - name: Run tests
       run: swift test --enable-test-discovery
 
+  # Windows support is still very much a work in progress
+  # We use a different action here to be able to use a more
+  # up-to-date toolchain.
   build_and_test_spm_windows:
     needs: cancel_previous
     runs-on: windows-latest
     steps:
-    - uses: compnerd/gha-setup-swift@main
-      with:
-        branch: swift-5.8-release
-        tag: 5.8-RELEASE
-    - uses: actions/checkout@v2
-    - name: Build
-      run: swift build
-    - name: Run tests
-      run: swift test --enable-test-discovery
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          release-tag-name: "20231116.2"
+          github-repo: "thebrowsercompany/swift-build"
+          release-asset-name: installer-amd64.exe
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test --enable-test-discovery
 
   build_and_test_ios:
     needs: cancel_previous

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: styfle/cancel-workflow-action@0.9.1
       with:
         workflow_id: ${{ github.event.workflow.id }}
-        
+
   build_and_test_spm_mac:
     needs: cancel_previous
     runs-on: macos-latest
@@ -37,6 +37,23 @@ jobs:
     - uses: fwal/setup-swift@v1.21.0
       with:
         swift-version: "5.7.2"
+    - uses: actions/checkout@v2
+    - uses: webfactory/ssh-agent@v0.5.3
+      with:
+        ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
+    - name: Build
+      run: swift build
+    - name: Run tests
+      run: swift test --enable-test-discovery
+
+  build_and_test_spm_windows:
+    needs: cancel_previous
+    runs-on: windows-latest
+    steps:
+    - uses: compnerd/gha-setup-swift@main
+      with:
+        branch: swift-5.8-release
+        tag: 5.8-RELEASE
     - uses: actions/checkout@v2
     - uses: webfactory/ssh-agent@v0.5.3
       with:
@@ -85,7 +102,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
     - run: xcodebuild -scheme Segment test -sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Series 8 (45mm)'
-    
+
   build_and_test_examples:
     needs: cancel_previous
     runs-on: macos-latest
@@ -117,4 +134,3 @@ jobs:
       run: |
           cd Examples/apps/SegmentUIKitExample
           xcodebuild -workspace "SegmentUIKitExample.xcworkspace" -scheme "SegmentUIKitExample" -destination 'platform=macOS,variant=Mac Catalyst'
- 

--- a/Examples/other_plugins/NotificationTracking.swift
+++ b/Examples/other_plugins/NotificationTracking.swift
@@ -33,7 +33,7 @@
 
 // MARK: Common
 
-#if !os(Linux) && !os(macOS)
+#if !os(Linux) && !os(macOS) && !os(Windows)
 
 import Foundation
 import Segment
@@ -41,7 +41,7 @@ import Segment
 class NotificationTracking: Plugin {
     var type: PluginType = .utility
     weak var analytics: Analytics?
-    
+
     func trackNotification(_ properties: [String: Codable], fromLaunch launch: Bool) {
         if launch {
             analytics?.track(name: "Push Notification Tapped", properties: properties)
@@ -95,4 +95,3 @@ extension NotificationTracking: iOSLifecycle {
 }
 
 #endif
-

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,14 +5,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/segmentio/jsonsafeencoder-swift.git",
       "state" : {
-        "revision" : "75ad40f07d4e0b938e3afb80811244d6b7acd4ba",
-        "version" : "1.0.0"
+        "revision" : "8b70dc8c01b7b041912e30e29d2b488a43f782ac",
+        "version" : "1.0.1"
       }
     },
     {
       "identity" : "sovran-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/segmentio/Sovran-Swift.git",
+      "location" : "https://github.com/segmentio/sovran-swift.git",
       "state" : {
         "revision" : "64f3b5150c282a34af4578188dce2fd597e600e3",
         "version" : "1.1.0"

--- a/Package.swift
+++ b/Package.swift
@@ -20,13 +20,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-<<<<<<< HEAD
-        .package(url: "https://github.com/segmentio/sovran-swift.git", from: "1.1.0"),
-        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.1")
-=======
         .package(url: "https://github.com/segmentio/sovran-swift.git", from: "1.1.1"),
-        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.0")
->>>>>>> main
+        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/segmentio/sovran-swift.git", from: "1.1.0"),
-        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.0")
+        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -21,13 +21,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-<<<<<<< HEAD
-        .package(url: "https://github.com/segmentio/sovran-swift.git", from: "1.1.0"),
-        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.1")
-=======
         .package(url: "https://github.com/segmentio/sovran-swift.git", from: "1.1.1"),
-        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.0")
->>>>>>> main
+        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -22,7 +22,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/segmentio/sovran-swift.git", from: "1.1.0"),
-        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.0")
+        .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -28,12 +28,8 @@ public class Analytics {
 
     static internal let deadInstance = "DEADINSTANCE"
     static internal weak var firstInstance: Analytics? = nil
-<<<<<<< HEAD
-
-=======
     @Atomic static internal var activeWriteKeys = [String]()
     
->>>>>>> main
     /**
      This method isn't a traditional singleton implementation.  It's provided here
      to ease migration from analytics-ios to analytics-swift.  Rather than return a
@@ -84,15 +80,11 @@ public class Analytics {
         // Get everything running
         platformStartup()
     }
-<<<<<<< HEAD
-
-=======
     
     deinit {
         Self.removeActiveWriteKey(configuration.values.writeKey)
     }
     
->>>>>>> main
     internal func process<E: RawEvent>(incomingEvent: E) {
         guard enabled == true else { return }
         let event = incomingEvent.applyRawEventData(store: store)
@@ -447,11 +439,7 @@ extension Analytics {
             Self.firstInstance = self
         }
     }
-<<<<<<< HEAD
 
-=======
-    
->>>>>>> main
     /// Determines if an instance is dead.
     internal var isDead: Bool {
         return configuration.values.writeKey == Self.deadInstance

--- a/Sources/Segment/Configuration.swift
+++ b/Sources/Segment/Configuration.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import JSONSafeEncoder
-#if os(Linux)
+#if os(Linux) || os(Windows)
 import FoundationNetworking
 #endif
 
@@ -18,7 +18,7 @@ public enum OperatingMode {
     case synchronous
     /// The operation of the Analytics client are asynchronous.
     case asynchronous
-    
+
     static internal let defaultQueue = DispatchQueue(label: "com.segment.operatingModeQueue", qos: .utility)
 }
 
@@ -43,11 +43,11 @@ public class Configuration {
         var userAgent: String? = nil
         var jsonNonConformingNumberStrategy: JSONSafeEncoder.NonConformingFloatEncodingStrategy = .zero
     }
-    
+
     internal var values: Values
 
     /// Initialize a configuration object to pass along to an Analytics instance.
-    /// 
+    ///
     /// - Parameter writeKey: Your Segment write key value
     public init(writeKey: String) {
         self.values = Values(writeKey: writeKey)
@@ -57,7 +57,7 @@ public class Configuration {
         settings.integrations = try? JSON([
             "Segment.io": true
         ])
-        
+
         self.defaultSettings(settings)
     }
 }
@@ -66,7 +66,7 @@ public class Configuration {
 // MARK: - Analytics Configuration
 
 public extension Configuration {
-    
+
     /// Sets a reference to your application.  This can be useful in instances
     /// where referring back to your application is necessary, such as within plugins
     /// or async code.  The default value is `nil`.
@@ -78,7 +78,7 @@ public extension Configuration {
         values.application = value
         return self
     }
-    
+
     /// Opt-in/out of tracking lifecycle events.  The default value is `false`.
     ///
     /// - Parameter enabled: A bool value
@@ -88,7 +88,7 @@ public extension Configuration {
         values.trackApplicationLifecycleEvents = enabled
         return self
     }
-    
+
     /// Set the number of events necessary to automatically flush. The default
     /// value is `20`.
     ///
@@ -99,7 +99,7 @@ public extension Configuration {
         values.flushAt = count
         return self
     }
-    
+
     /// Set a time interval (in seconds) by which to trigger an automatic flush.
     /// The default value is `30`.
     ///
@@ -110,7 +110,7 @@ public extension Configuration {
         values.flushInterval = interval
         return self
     }
-    
+
     /// Sets a default set of Settings.  Normally these will come from Segment's
     /// api.segment.com/v1/projects/<writekey>/settings, however in instances such
     /// as first app launch, it can be useful to have a pre-set batch of settings to
@@ -127,14 +127,14 @@ public extension Configuration {
     /// let config = Configuration(writeKey: "1234").defaultSettings(defaults)
     /// ```
     ///
-    /// - Parameter settings: 
+    /// - Parameter settings:
     /// - Returns: The current Configuration.
     @discardableResult
     func defaultSettings(_ settings: Settings?) -> Configuration {
         values.defaultSettings = settings
         return self
     }
-    
+
     /// Enable/Disable the automatic adding of Segment as a destination.
     /// This can be useful in instances such as Consent Management, or in device
     /// mode only setups.  The default value is `true`.
@@ -146,7 +146,7 @@ public extension Configuration {
         values.autoAddSegmentDestination = value
         return self
     }
-    
+
     /// Sets an alternative API host.  This is useful when a proxy is in use, or
     /// events need to be routed to certain locales at all times (such as the EU).
     /// The default value is `api.segment.io/v1`.
@@ -158,7 +158,7 @@ public extension Configuration {
         values.apiHost = value
         return self
     }
-    
+
     /// Sets an alternative CDN host for settings retrieval. This is useful when
     /// a proxy is in use, or settings need to be queried from certain locales at
     /// all times (such as the EU). The default value is `cdn-settings.segment.com/v1`.
@@ -170,7 +170,7 @@ public extension Configuration {
         values.cdnHost = value
         return self
     }
-    
+
     /// Sets a block to be used when generating outgoing HTTP requests.  Useful in
     /// proxying, or adding additional header information for outbound traffic.
     ///
@@ -181,7 +181,7 @@ public extension Configuration {
         values.requestFactory = value
         return self
     }
-    
+
     /// Sets an error handler to be called when errors are encountered by the Segment
     /// library.  See `AnalyticsError` for a list of possible errors that can be
     /// encountered.
@@ -193,13 +193,13 @@ public extension Configuration {
         values.errorHandler = value
         return self
     }
-    
+
     @discardableResult
     func flushPolicies(_ policies: [FlushPolicy]) -> Configuration {
         values.flushPolicies = policies
         return self
     }
-    
+
     /// Informs the Analytics instance of its operating mode/context.
     /// Use `.server` when operating in a web service, or when synchronous operation
     /// is desired.  Use `.client` when operating in a long lived process,
@@ -209,7 +209,7 @@ public extension Configuration {
         values.operatingMode = mode
         return self
     }
-    
+
     /// Specify a custom queue to use when performing a flush operation.  The default
     /// value is a Segment owned background queue.
     @discardableResult
@@ -224,7 +224,7 @@ public extension Configuration {
         values.userAgent = userAgent
         return self
     }
-    
+
     /// This option specifies how NaN/Infinity are handled when encoding JSON.
     /// The default is .zero.  See JSONSafeEncoder.NonConformingFloatEncodingStrategy for more informatino.
     @discardableResult

--- a/Sources/Segment/ObjC/ObjCAnalytics.swift
+++ b/Sources/Segment/ObjC/ObjCAnalytics.swift
@@ -1,11 +1,11 @@
 //
 //  ObjCAnalytics.swift
-//  
+//
 //
 //  Created by Cody Garvin on 6/10/21.
 //
 
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 
 import Foundation
 import JSONSafeEncoder
@@ -16,12 +16,12 @@ import JSONSafeEncoder
 public class ObjCAnalytics: NSObject {
     /// The underlying Analytics object we're working with
     public let analytics: Analytics
-    
+
     @objc
     public init(configuration: ObjCConfiguration) {
         self.analytics = Analytics(configuration: configuration.configuration)
     }
-    
+
     /// Get a workable ObjC instance by wrapping a Swift instance
     /// Useful when you want additional flexibility or to share
     /// a single instance between ObjC<>Swift.
@@ -38,7 +38,7 @@ extension ObjCAnalytics {
     public func track(name: String) {
         track(name: name, properties: nil)
     }
-    
+
 
     @objc(track:properties:)
     public func track(name: String, properties: [String: Any]?) {
@@ -77,7 +77,7 @@ extension ObjCAnalytics {
             analytics.process(incomingEvent: event)
         }
     }
-    
+
     /// Track a screen change with a title, category and other properties.
     /// - Parameters:
     ///   - title: The title of the screen being tracked.
@@ -85,7 +85,7 @@ extension ObjCAnalytics {
     public func screen(title: String) {
         screen(title: title, category: nil, properties: nil)
     }
-    
+
     /// Track a screen change with a title, category and other properties.
     /// - Parameters:
     ///   - title: The title of the screen being tracked.
@@ -120,7 +120,7 @@ extension ObjCAnalytics {
     public func group(groupId: String, traits: [String: Any]?) {
         analytics.group(groupId: groupId, traits: traits)
     }
-    
+
     @objc(alias:)
     /// The alias method is used to merge two user identities, effectively connecting two sets of user data
     /// as one. This is an advanced method, but it is required to manage user identities successfully in some of our destinations.
@@ -139,27 +139,27 @@ extension ObjCAnalytics {
     public var anonymousId: String {
         return analytics.anonymousId
     }
-    
+
     @objc
     public var userId: String? {
         return analytics.userId
     }
-    
+
     @objc
     public func traits() -> [String: Any]? {
         return analytics.traits()
     }
-    
+
     @objc
     public func flush() {
         analytics.flush()
     }
-    
+
     @objc
     public func reset() {
         analytics.reset()
     }
-    
+
     @objc
     public func settings() -> [String: Any]? {
         var result: [String: Any]? = nil
@@ -177,12 +177,12 @@ extension ObjCAnalytics {
         }
         return result
     }
-    
+
     @objc
     public func openURL(_ url: URL, options: [String: Any] = [:]) {
         analytics.openURL(url, options: options)
     }
-    
+
     @objc
     public func version() -> String {
         return analytics.version()

--- a/Sources/Segment/ObjC/ObjCConfiguration.swift
+++ b/Sources/Segment/ObjC/ObjCConfiguration.swift
@@ -1,11 +1,11 @@
 //
 //  ObjCConfiguration.swift
-//  
+//
 //
 //  Created by Brandon Sneed on 8/13/21.
 //
 
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 
 import Foundation
 import JSONSafeEncoder
@@ -13,7 +13,7 @@ import JSONSafeEncoder
 @objc(SEGConfiguration)
 public class ObjCConfiguration: NSObject {
     internal var configuration: Configuration
-    
+
     /// Sets a reference to your application.  This can be useful in instances
     /// where referring back to your application is necessary, such as within plugins
     /// or async code.  The default value is `nil`.
@@ -26,7 +26,7 @@ public class ObjCConfiguration: NSObject {
             configuration.application(value)
         }
     }
-    
+
     /// Opt-in/out of tracking lifecycle events.  The default value is `false`.
     @objc
     public var trackApplicationLifecycleEvents: Bool {
@@ -37,7 +37,7 @@ public class ObjCConfiguration: NSObject {
             configuration.trackApplicationLifecycleEvents(value)
         }
     }
-    
+
     /// Set the number of events necessary to automatically flush. The default
     /// value is `20`.
     @objc
@@ -49,7 +49,7 @@ public class ObjCConfiguration: NSObject {
             configuration.flushAt(value)
         }
     }
-    
+
     /// Set a time interval (in seconds) by which to trigger an automatic flush.
     /// The default value is `30`.
     @objc
@@ -61,7 +61,7 @@ public class ObjCConfiguration: NSObject {
             configuration.flushInterval(value)
         }
     }
-    
+
     /// Sets a default set of Settings.  Normally these will come from Segment's
     /// api.segment.com/v1/projects/<writekey>/settings, however in instances such
     /// as first app launch, it can be useful to have a pre-set batch of settings to
@@ -98,7 +98,7 @@ public class ObjCConfiguration: NSObject {
             }
         }
     }
-    
+
     /// Enable/Disable the automatic adding of Segment as a destination.
     /// This can be useful in instances such as Consent Management, or in device
     /// mode only setups.  The default value is `true`.
@@ -111,7 +111,7 @@ public class ObjCConfiguration: NSObject {
             configuration.autoAddSegmentDestination(value)
         }
     }
-    
+
     /// Sets an alternative API host.  This is useful when a proxy is in use, or
     /// events need to be routed to certain locales at all times (such as the EU).
     /// The default value is `api.segment.io/v1`.
@@ -137,7 +137,7 @@ public class ObjCConfiguration: NSObject {
             configuration.cdnHost(value)
         }
     }
-    
+
     /// Sets a block to be used when generating outgoing HTTP requests.  Useful in
     /// proxying, or adding additional header information for outbound traffic.
     ///
@@ -163,4 +163,3 @@ public class ObjCConfiguration: NSObject {
 }
 
 #endif
-

--- a/Sources/Segment/ObjC/ObjCEvents.swift
+++ b/Sources/Segment/ObjC/ObjCEvents.swift
@@ -1,11 +1,11 @@
 //
 //  ObjCEvents.swift
-//  
+//
 //
 //  Created by Brandon Sneed on 4/17/23.
 //
 
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 
 import Foundation
 
@@ -17,27 +17,27 @@ internal protocol ObjCEvent {
 @objc(SEGDestinationMetadata)
 public class ObjCDestinationMetadata: NSObject {
     internal var _metadata: DestinationMetadata
-    
+
     public var bundled: [String] {
         get { return _metadata.bundled }
         set(v) { _metadata.bundled = v }
     }
-    
+
     public var unbundled: [String] {
         get { return _metadata.unbundled }
         set(v) { _metadata.unbundled = v }
     }
-    
+
     public var bundledIds: [String] {
         get { return _metadata.bundledIds }
         set(v) { _metadata.bundledIds = v }
     }
-    
+
     internal init?(_metadata: DestinationMetadata?) {
         guard let m = _metadata else { return nil }
         self._metadata = m
     }
-    
+
     init(bundled: [String], unbundled: [String], bundledIds: [String]) {
         _metadata = DestinationMetadata(bundled: bundled, unbundled: unbundled, bundledIds: bundledIds)
     }
@@ -50,7 +50,7 @@ public protocol ObjCRawEvent: NSObjectProtocol {
     var timestamp: String? { get }
     var anonymousId: String? { get set }
     var userId: String? { get set }
-    
+
     var context: [String: Any]? { get set }
     var integrations: [String: Any]? { get set }
 
@@ -83,46 +83,46 @@ internal func objcEventFromEvent<T: RawEvent>(_ event: T?) -> ObjCRawEvent? {
 @objc(SEGTrackEvent)
 public class ObjCTrackEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: TrackEvent
-    
+
     // RawEvent components
-    
+
     public var type: String? { return _event.type }
     public var messageId: String? { return _event.messageId }
     public var timestamp: String? { return _event.timestamp }
-    
+
     public var anonymousId: String? {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var userId: String? {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var context: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var integrations: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var metadata: ObjCDestinationMetadata? {
         get { return ObjCDestinationMetadata(_metadata: _event._metadata) }
         set(v) { _event._metadata = v?._metadata }
     }
-    
+
     // Event Specific
-    
+
     @objc
     public var event: String {
         get { return _event.event }
         set(v) { _event.event = v }
     }
-    
+
     @objc
     public var properties: [String: Any]? {
         get { return _event.properties?.dictionaryValue }
@@ -133,7 +133,7 @@ public class ObjCTrackEvent: NSObject, ObjCEvent, ObjCRawEvent {
     public init(name: String, properties: [String: Any]? = nil) {
         _event = TrackEvent(event: name, properties: try? JSON(nilOrObject: properties))
     }
-    
+
     internal init(event: EventType) {
         self._event = event
     }
@@ -142,9 +142,9 @@ public class ObjCTrackEvent: NSObject, ObjCEvent, ObjCRawEvent {
 @objc(SEGIdentifyEvent)
 public class ObjCIdentifyEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: IdentifyEvent
-    
+
     // RawEvent components
-    
+
     public var type: String? { return _event.type }
     public var messageId: String? { return _event.messageId }
     public var timestamp: String? { return _event.timestamp }
@@ -153,29 +153,29 @@ public class ObjCIdentifyEvent: NSObject, ObjCEvent, ObjCRawEvent {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var userId: String? {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var context: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var integrations: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var metadata: ObjCDestinationMetadata? {
         get { return ObjCDestinationMetadata(_metadata: _event._metadata) }
         set(v) { _event._metadata = v?._metadata }
     }
-    
+
     // Event Specific
-    
+
     @objc
     public var traits: [String: Any]? {
         get { return _event.traits?.dictionaryValue }
@@ -186,7 +186,7 @@ public class ObjCIdentifyEvent: NSObject, ObjCEvent, ObjCRawEvent {
     public init(userId: String, traits: [String: Any]? = nil) {
         _event = IdentifyEvent(userId: userId, traits: try? JSON(nilOrObject: traits))
     }
-    
+
     internal init(event: EventType) {
         self._event = event
     }
@@ -195,9 +195,9 @@ public class ObjCIdentifyEvent: NSObject, ObjCEvent, ObjCRawEvent {
 @objc(SEGScreenEvent)
 public class ObjCScreenEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: ScreenEvent
-    
+
     // RawEvent components
-    
+
     public var type: String? { return _event.type }
     public var messageId: String? { return _event.messageId }
     public var timestamp: String? { return _event.timestamp }
@@ -206,41 +206,41 @@ public class ObjCScreenEvent: NSObject, ObjCEvent, ObjCRawEvent {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var userId: String? {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var context: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var integrations: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var metadata: ObjCDestinationMetadata? {
         get { return ObjCDestinationMetadata(_metadata: _event._metadata) }
         set(v) { _event._metadata = v?._metadata }
     }
-    
+
     // Event Specific
-    
+
     @objc
     public var name: String? {
         get { return _event.name }
         set(v) { _event.name = v}
     }
-    
+
     @objc
     public var category: String? {
         get { return _event.category }
         set(v) { _event.category = v}
     }
-    
+
     @objc
     public var properties: [String: Any]? {
         get { return _event.properties?.dictionaryValue }
@@ -251,7 +251,7 @@ public class ObjCScreenEvent: NSObject, ObjCEvent, ObjCRawEvent {
     public init(name: String, category: String?, properties: [String: Any]? = nil) {
         _event = ScreenEvent(title: name, category: category, properties: try? JSON(nilOrObject: properties))
     }
-    
+
     internal init(event: EventType) {
         self._event = event
     }
@@ -260,9 +260,9 @@ public class ObjCScreenEvent: NSObject, ObjCEvent, ObjCRawEvent {
 @objc(SEGGroupEvent)
 public class ObjCGroupEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: GroupEvent
-    
+
     // RawEvent components
-    
+
     public var type: String? { return _event.type }
     public var messageId: String? { return _event.messageId }
     public var timestamp: String? { return _event.timestamp }
@@ -271,35 +271,35 @@ public class ObjCGroupEvent: NSObject, ObjCEvent, ObjCRawEvent {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var userId: String? {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var context: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var integrations: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var metadata: ObjCDestinationMetadata? {
         get { return ObjCDestinationMetadata(_metadata: _event._metadata) }
         set(v) { _event._metadata = v?._metadata }
     }
-    
+
     // Event Specific
-    
+
     @objc
     public var groupId: String? {
         get { return _event.groupId }
         set(v) { _event.groupId = v}
     }
-    
+
     @objc
     public var traits: [String: Any]? {
         get { return _event.traits?.dictionaryValue }
@@ -310,7 +310,7 @@ public class ObjCGroupEvent: NSObject, ObjCEvent, ObjCRawEvent {
     public init(groupId: String?, traits: [String: Any]? = nil) {
         _event = GroupEvent(groupId: groupId, traits: try? JSON(nilOrObject: traits))
     }
-    
+
     internal init(event: EventType) {
         self._event = event
     }
@@ -319,9 +319,9 @@ public class ObjCGroupEvent: NSObject, ObjCEvent, ObjCRawEvent {
 @objc(SEGAliasEvent)
 public class ObjCAliasEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: AliasEvent
-    
+
     // RawEvent components
-    
+
     public var type: String? { return _event.type }
     public var messageId: String? { return _event.messageId }
     public var timestamp: String? { return _event.timestamp }
@@ -330,29 +330,29 @@ public class ObjCAliasEvent: NSObject, ObjCEvent, ObjCRawEvent {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var userId: String? {
         get { return _event.anonymousId }
         set(v) { _event.anonymousId = v}
     }
-    
+
     public var context: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var integrations: [String: Any]? {
         get { return _event.context?.dictionaryValue }
         set(v) { _event.context = try? JSON(nilOrObject: v)}
     }
-    
+
     public var metadata: ObjCDestinationMetadata? {
         get { return ObjCDestinationMetadata(_metadata: _event._metadata) }
         set(v) { _event._metadata = v?._metadata }
     }
-    
+
     // Event Specific
-    
+
     @objc
     public var previousId: String? {
         get { return _event.previousId }
@@ -363,7 +363,7 @@ public class ObjCAliasEvent: NSObject, ObjCEvent, ObjCRawEvent {
     public init(newId: String?) {
         _event = AliasEvent(newId: newId)
     }
-    
+
     internal init(event: EventType) {
         self._event = event
     }

--- a/Sources/Segment/ObjC/ObjCPlugin.swift
+++ b/Sources/Segment/ObjC/ObjCPlugin.swift
@@ -1,12 +1,12 @@
 //
 //  ObjCPlugin.swift
-//  
+//
 //
 //  Created by Brandon Sneed on 4/17/23.
 //
 
 
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 
 import Foundation
 
@@ -31,7 +31,7 @@ public class ObjCSegmentMixpanel: NSObject, ObjCPlugin, ObjCPluginShim {
 public class ObjCEventPlugin: NSObject, EventPlugin, ObjCPlugin {
     public var type: PluginType = .enrichment
     public var analytics: Analytics? = nil
-    
+
     @objc(executeEvent:)
     public func execute(event: ObjCRawEvent?) -> ObjCRawEvent? {
         #if DEBUG
@@ -39,7 +39,7 @@ public class ObjCEventPlugin: NSObject, EventPlugin, ObjCPlugin {
         #endif
         return event
     }
-    
+
     public func execute<T>(event: T?) -> T? where T : RawEvent {
         let objcEvent = objcEventFromEvent(event)
         let result = execute(event: objcEvent)
@@ -51,12 +51,12 @@ public class ObjCEventPlugin: NSObject, EventPlugin, ObjCPlugin {
 @objc(SEGBlockPlugin)
 public class ObjCBlockPlugin: ObjCEventPlugin {
     let block: (ObjCRawEvent?) -> ObjCRawEvent?
-    
+
     @objc(executeEvent:)
     public override func execute(event: ObjCRawEvent?) -> ObjCRawEvent? {
         return block(event)
     }
-    
+
     @objc(initWithBlock:)
     public init(block: @escaping (ObjCRawEvent?) -> ObjCRawEvent?) {
         self.block = block
@@ -73,11 +73,11 @@ extension ObjCAnalytics {
             analytics.add(plugin: p)
         }
     }
-    
+
     @objc(addPlugin:destinationKey:)
     public func add(plugin: ObjCPlugin?, destinationKey: String) {
         guard let d = analytics.find(key: destinationKey) else { return }
-        
+
         if let p = plugin as? ObjCPluginShim {
             _ = d.add(plugin: p.instance())
         } else if let p = plugin as? ObjCEventPlugin {
@@ -87,4 +87,3 @@ extension ObjCAnalytics {
 }
 
 #endif
-

--- a/Sources/Segment/Plugins/Platforms/Vendors/WindowsUtils.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/WindowsUtils.swift
@@ -5,71 +5,71 @@ import Foundation
 import WinSDK
 
 internal class WindowsVendorSystem: VendorSystem {
-	override var manufacturer: String {
-		return "unknown"
-	}
+    override var manufacturer: String {
+        return "unknown"
+    }
 
-	override var type: String {
-		return "Windows"
-	}
+    override var type: String {
+        return "Windows"
+    }
 
-	override var model: String {
-		return "unknown"
-	}
+    override var model: String {
+        return "unknown"
+    }
 
-	override var name: String {
-		return "unknown"
-	}
+    override var name: String {
+        return "unknown"
+    }
 
-	override var identifierForVendor: String? {
-		return nil
-	}
+    override var identifierForVendor: String? {
+        return nil
+    }
 
-	override var systemName: String {
-		// If the name is larger than 256 characters, we might get an error.
-		var size: DWORD = 256
-		var buffer = [CHAR](repeating: 0, count: Int(size))
-		guard GetComputerNameA(&buffer, &size) else {
-			return "unknown"
-		}
+    override var systemName: String {
+        // If the name is larger than 256 characters, we might get an error.
+        var size: DWORD = 256
+        var buffer = [CHAR](repeating: 0, count: Int(size))
+        guard GetComputerNameA(&buffer, &size) else {
+            return "unknown"
+        }
 
-		return String(cString: buffer)
-	}
+        return String(cString: buffer)
+    }
 
-	override var systemVersion: String {
-		let version = ProcessInfo.processInfo.operatingSystemVersion
-		return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
-	}
+    override var systemVersion: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
 
-	override var screenSize: ScreenSize {
-		var rect: RECT = .init(left: 0, top: 0, right: 0, bottom: 0)
-		guard SystemParametersInfoA(UInt32(SPI_GETWORKAREA), 0, &rect, 0) else {
-			return ScreenSize(width: 0, height: 0)
-		}
+    override var screenSize: ScreenSize {
+        var rect: RECT = .init(left: 0, top: 0, right: 0, bottom: 0)
+        guard SystemParametersInfoA(UInt32(SPI_GETWORKAREA), 0, &rect, 0) else {
+            return ScreenSize(width: 0, height: 0)
+        }
 
-		return ScreenSize(width: rect.width, height: rect.height)
-	}
+        return ScreenSize(width: rect.width, height: rect.height)
+    }
 
-	override var userAgent: String? {
-		return "unknown"
-	}
+    override var userAgent: String? {
+        return "unknown"
+    }
 
-	override var connection: ConnectionStatus {
-		return .unknown
-	}
+    override var connection: ConnectionStatus {
+        return .unknown
+    }
 
-	override var requiredPlugins: [any PlatformPlugin] {
-		[]
-	}
+    override var requiredPlugins: [any PlatformPlugin] {
+        []
+    }
 }
 
 extension RECT {
-	internal var width: Double {
-		Double(right - left)
-	}
+    internal var width: Double {
+        Double(right - left)
+    }
 
-	internal var height: Double {
-		Double(bottom - top)
-	}
+    internal var height: Double {
+        Double(bottom - top)
+    }
 }
 #endif

--- a/Sources/Segment/Plugins/Platforms/Vendors/WindowsUtils.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/WindowsUtils.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+#if os(Windows)
+
+import WinSDK
+
+internal class WindowsVendorSystem: VendorSystem {
+	override var manufacturer: String {
+		return "unknown"
+	}
+
+	override var type: String {
+		return "Windows"
+	}
+
+	override var model: String {
+		return "unknown"
+	}
+
+	override var name: String {
+		return "unknown"
+	}
+
+	override var identifierForVendor: String? {
+		return nil
+	}
+
+	override var systemName: String {
+		// If the name is larger than 256 characters, we might get an error.
+		var size: DWORD = 256
+		var buffer = [CHAR](repeating: 0, count: Int(size))
+		guard GetComputerNameA(&buffer, &size) else {
+			return "unknown"
+		}
+
+		return String(cString: buffer)
+	}
+
+	override var systemVersion: String {
+		let version = ProcessInfo.processInfo.operatingSystemVersion
+		return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+	}
+
+	override var screenSize: ScreenSize {
+		var rect: RECT = .init(left: 0, top: 0, right: 0, bottom: 0)
+		guard SystemParametersInfoA(UInt32(SPI_GETWORKAREA), 0, &rect, 0) else {
+			return ScreenSize(width: 0, height: 0)
+		}
+
+		return ScreenSize(width: rect.width, height: rect.height)
+	}
+
+	override var userAgent: String? {
+		return "unknown"
+	}
+
+	override var connection: ConnectionStatus {
+		return .unknown
+	}
+
+	override var requiredPlugins: [any PlatformPlugin] {
+		[]
+	}
+}
+
+extension RECT {
+	internal var width: Double {
+		Double(right - left)
+	}
+
+	internal var height: Double {
+		Double(bottom - top)
+	}
+}
+#endif

--- a/Sources/Segment/Startup.swift
+++ b/Sources/Segment/Startup.swift
@@ -9,10 +9,10 @@ import Foundation
 import Sovran
 
 extension Analytics: Subscriber {
-        
+
     internal func platformStartup() {
         add(plugin: StartupQueue())
-        
+
         // add segment destination plugin unless
         // asked not to via configuration.
         if configuration.values.autoAddSegmentDestination {
@@ -20,31 +20,31 @@ extension Analytics: Subscriber {
             segmentDestination.analytics = self
             add(plugin: segmentDestination)
         }
-        
+
         // Setup platform specific plugins
         if let platformPlugins = platformPlugins() {
             for plugin in platformPlugins {
                 add(plugin: plugin)
             }
         }
-        
+
         for policy in configuration.values.flushPolicies {
             policy.configure(analytics: self)
         }
-        
+
         // plugins will receive any settings we currently have as they are added.
         // ... but lets go check if we have new stuff ....
         // start checking periodically for settings changes from segment.com
         setupSettingsCheck()
     }
-    
+
     internal func platformPlugins() -> [PlatformPlugin]? {
         var plugins = [PlatformPlugin]()
-        
+
         // add context plugin as well as it's platform specific internally.
         // this must come first.
         plugins.append(Context())
-        
+
         plugins += VendorSystem.current.requiredPlugins
 
         // setup lifecycle if desired
@@ -62,8 +62,11 @@ extension Analytics: Subscriber {
             // placeholder - not sure what this is yet
             //plugins.append(LinuxLifecycleMonitor())
             #endif
+            #if os(Windows)
+            // placeholder - not sure what this is yet
+            #endif
         }
-        
+
         if plugins.isEmpty {
             return nil
         } else {
@@ -109,6 +112,12 @@ extension Analytics {
     }
 }
 #elseif os(Linux)
+extension Analytics {
+    internal func setupSettingsCheck() {
+        checkSettings()
+    }
+}
+#elseif os(Windows)
 extension Analytics {
     internal func setupSettingsCheck() {
         checkSettings()

--- a/Sources/Segment/Utilities/OutputFileStream.swift
+++ b/Sources/Segment/Utilities/OutputFileStream.swift
@@ -1,6 +1,6 @@
 //
 //  OutputFileStream.swift
-//  
+//
 //
 //  Created by Brandon Sneed on 10/15/22.
 //
@@ -11,6 +11,8 @@ import Foundation
 
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import WinSDK
 #else
 import Darwin.C
 #endif
@@ -23,16 +25,16 @@ internal class OutputFileStream {
         case unableToCreate(String)
         case unableToClose(String)
     }
-    
+
     var fileHandle: FileHandle? = nil
     let fileURL: URL
-    
+
     init(fileURL: URL) throws {
         self.fileURL = fileURL
         let path = fileURL.path
         guard path.isEmpty == false else { throw OutputStreamError.invalidPath(path) }
     }
-    
+
     /// Create attempts to create + open
     func create() throws {
         let path = fileURL.path
@@ -47,7 +49,7 @@ internal class OutputFileStream {
             }
         }
     }
-    
+
     /// Open simply opens the file, no attempt at creation is made.
     func open() throws {
         if fileHandle != nil { return }
@@ -65,7 +67,7 @@ internal class OutputFileStream {
             throw OutputStreamError.unableToOpen(fileURL.path)
         }
     }
-    
+
     func write(_ data: Data) throws {
         guard data.isEmpty == false else { return }
         if #available(macOS 10.15.4, iOS 13.4, macCatalyst 13.4, tvOS 13.4, watchOS 13.4, *) {
@@ -79,14 +81,14 @@ internal class OutputFileStream {
             fileHandle?.write(data)
         }
     }
-    
+
     func write(_ string: String) throws {
         guard string.isEmpty == false else { return }
         if let data = string.data(using: .utf8) {
             try write(data)
         }
     }
-    
+
     func close() throws {
         do {
             let existing = fileHandle

--- a/Sources/Segment/Utilities/Utils.swift
+++ b/Sources/Segment/Utilities/Utils.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if os(Linux) || os(Windows)
 extension DispatchQueue {
     func asyncAndWait(execute workItem: DispatchWorkItem) {
         async {
@@ -73,33 +73,33 @@ extension Optional: Flattenable {
 #if DEBUG
 class TrackingDispatchGroup: CustomStringConvertible {
     internal let group = DispatchGroup()
-    
+
     var description: String {
         return "DispatchGroup Enters: \(enters), Leaves: \(leaves)"
     }
-    
+
     var enters: Int = 0
     var leaves: Int = 0
     var current: Int = 0
-    
+
     func enter() {
         enters += 1
         current += 1
         group.enter()
     }
-    
+
     func leave() {
         leaves += 1
         current -= 1
         group.leave()
     }
-    
+
     init() { }
-    
+
     func wait() {
         group.wait()
     }
-    
+
     public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @escaping @convention(block) () -> Void) {
         group.notify(qos: qos, flags: flags, queue: queue, execute: work)
     }

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -2,39 +2,39 @@ import XCTest
 @testable import Segment
 
 final class Analytics_Tests: XCTestCase {
-    
+
     func testBaseEventCreation() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let myDestination = MyDestination()
         myDestination.add(plugin: GooberPlugin())
-        
+
         analytics.add(plugin: ZiggyPlugin())
         analytics.add(plugin: myDestination)
-        
+
         let traits = MyTraits(email: "brandon@redf.net")
         analytics.identify(userId: "brandon", traits: traits)
     }
-    
+
     func testPluginConfigure() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let ziggy = ZiggyPlugin()
         let myDestination = MyDestination()
         let goober = GooberPlugin()
         myDestination.add(plugin: goober)
-        
+
         analytics.add(plugin: ziggy)
         analytics.add(plugin: myDestination)
-        
+
         XCTAssertNotNil(ziggy.analytics)
         XCTAssertNotNil(myDestination.analytics)
         XCTAssertNotNil(goober.analytics)
     }
-    
+
     func testPluginRemove() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let myDestination = MyDestination()
         myDestination.add(plugin: GooberPlugin())
-        
+
         let expectation = XCTestExpectation(description: "Ziggy Expectation")
         let ziggy = ZiggyPlugin()
         ziggy.completion = {
@@ -42,24 +42,24 @@ final class Analytics_Tests: XCTestCase {
         }
         analytics.add(plugin: ziggy)
         analytics.add(plugin: myDestination)
-        
+
         let traits = MyTraits(email: "brandon@redf.net")
         analytics.identify(userId: "brandon", traits: traits)
         analytics.remove(plugin: ziggy)
-        
+
         wait(for: [expectation], timeout: 1.0)
     }
-    
+
     func testDestinationInitialUpdateOnlyOnce() {
         // need to clear settings for this one.
         UserDefaults.standard.removePersistentDomain(forName: "com.segment.storage.test")
-        
+
         let expectation = XCTestExpectation(description: "MyDestination Expectation")
         let myDestination = MyDestination {
             expectation.fulfill()
             return true
         }
-        
+
         var settings = Settings(writeKey: "test")
         if let existing = settings.integrations?.dictionaryValue {
             var newIntegrations = existing
@@ -69,41 +69,41 @@ final class Analytics_Tests: XCTestCase {
         let configuration = Configuration(writeKey: "test")
         configuration.defaultSettings(settings)
         let analytics = Analytics(configuration: configuration)
-        
+
         let ziggy1 = ZiggyPlugin()
         analytics.add(plugin: myDestination)
         analytics.add(plugin: ziggy1)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.track(name: "testDestinationEnabled")
-        
+
         let ziggy2 = ZiggyPlugin()
         analytics.add(plugin: ziggy2)
-        
+
         let dest = analytics.find(key: myDestination.key)
         XCTAssertNotNil(dest)
         XCTAssertTrue(dest is MyDestination)
-        
+
         wait(for: [expectation], timeout: 1.0)
-        
+
         XCTAssertEqual(myDestination.receivedInitialUpdate, 1)
         XCTAssertEqual(ziggy1.receivedInitialUpdate, 1)
         XCTAssertEqual(ziggy2.receivedInitialUpdate, 1)
-        
+
     }
 
-    
+
     func testDestinationEnabled() {
         // need to clear settings for this one.
         UserDefaults.standard.removePersistentDomain(forName: "com.segment.storage.test")
-        
+
         let expectation = XCTestExpectation(description: "MyDestination Expectation")
         let myDestination = MyDestination {
             expectation.fulfill()
             return true
         }
-        
+
         var settings = Settings(writeKey: "test")
         if let existing = settings.integrations?.dictionaryValue {
             var newIntegrations = existing
@@ -113,60 +113,60 @@ final class Analytics_Tests: XCTestCase {
         let configuration = Configuration(writeKey: "test")
         configuration.defaultSettings(settings)
         let analytics = Analytics(configuration: configuration)
-        
+
         analytics.add(plugin: myDestination)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.track(name: "testDestinationEnabled")
-        
+
         let dest = analytics.find(key: myDestination.key)
         XCTAssertNotNil(dest)
         XCTAssertTrue(dest is MyDestination)
-        
+
         wait(for: [expectation], timeout: 1.0)
     }
-    
-    // Linux doesn't support XCTExpectFailure
-#if !os(Linux)
+
+    // Linux & Windows don't support XCTExpectFailure
+#if !os(Linux) && !os(Windows)
     func testDestinationNotEnabled() {
         // need to clear settings for this one.
         UserDefaults.standard.removePersistentDomain(forName: "com.segment.storage.test")
-        
+
         let expectation = XCTestExpectation(description: "MyDestination Expectation")
         let myDestination = MyDestination(disabled: true) {
             expectation.fulfill()
             return true
         }
-        
+
         let configuration = Configuration(writeKey: "test")
         let analytics = Analytics(configuration: configuration)
-        
+
         analytics.add(plugin: myDestination)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.track(name: "testDestinationEnabled")
-        
+
         XCTExpectFailure {
             wait(for: [expectation], timeout: 1.0)
         }
     }
 #endif
-    
+
     func testAnonymousId() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let anonId = analytics.anonymousId
-        
+
         XCTAssertTrue(anonId != "")
         XCTAssertTrue(anonId.count == 36) // it's a UUID y0.
     }
-    
+
     func testContext() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
 #if !os(watchOS) && !os(Linux)
         // prime the pump for userAgent, since it's retrieved async.
         let vendorSystem = VendorSystem.current
@@ -174,14 +174,14 @@ final class Analytics_Tests: XCTestCase {
             RunLoop.main.run(until: Date.distantPast)
         }
 #endif
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         // add a referrer
         analytics.openURL(URL(string: "https://google.com")!)
-        
+
         analytics.track(name: "token check")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         let context = trackEvent?.context?.dictionaryValue
         // Verify that context isn't empty here.
@@ -193,30 +193,30 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertNotNil(context?["timezone"], "timezone missing!")
         XCTAssertNotNil(context?["library"], "library missing!")
         XCTAssertNotNil(context?["device"], "device missing!")
-        
+
         let referrer = context?["referrer"] as! [String: Any]
         XCTAssertEqual(referrer["url"] as! String, "https://google.com")
-        
+
         // this key not present on watchOS (doesn't have webkit)
 #if !os(watchOS)
         XCTAssertNotNil(context?["userAgent"], "userAgent missing!")
 #endif
-        
-        // these keys not present on linux
-#if !os(Linux)
+
+        // these keys not present on linux or Windows
+#if !os(Linux) && !os(Windows)
         XCTAssertNotNil(context?["app"], "app missing!")
         XCTAssertNotNil(context?["locale"], "locale missing!")
 #endif
     }
-    
-    
+
+
     func testContextWithUserAgent() {
         let configuration = Configuration(writeKey: "test")
         configuration.userAgent("testing user agent")
         let analytics = Analytics(configuration: configuration)
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
 #if !os(watchOS) && !os(Linux)
         // prime the pump for userAgent, since it's retrieved async.
         let vendorSystem = VendorSystem.current
@@ -224,14 +224,14 @@ final class Analytics_Tests: XCTestCase {
             RunLoop.main.run(until: Date.distantPast)
         }
 #endif
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         // add a referrer
         analytics.openURL(URL(string: "https://google.com")!)
-        
+
         analytics.track(name: "token check")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         let context = trackEvent?.context?.dictionaryValue
         // Verify that context isn't empty here.
@@ -243,170 +243,170 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertNotNil(context?["timezone"], "timezone missing!")
         XCTAssertNotNil(context?["library"], "library missing!")
         XCTAssertNotNil(context?["device"], "device missing!")
-        
+
         let referrer = context?["referrer"] as! [String: Any]
         XCTAssertEqual(referrer["url"] as! String, "https://google.com")
 
         XCTAssertEqual(context?["userAgent"] as! String, "testing user agent")
-        
-        // these keys not present on linux
-#if !os(Linux)
+
+        // these keys not present on linux or Windows
+#if !os(Linux) && !os(Windows)
         XCTAssertNotNil(context?["app"], "app missing!")
         XCTAssertNotNil(context?["locale"], "locale missing!")
 #endif
     }
-    
+
     func testDeviceToken() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.setDeviceToken("1234")
         analytics.track(name: "token check")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         let device = trackEvent?.context?.dictionaryValue
         let token = device?[keyPath: "device.token"] as? String
         XCTAssertTrue(token == "1234")
     }
-    
+
 #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
     func testDeviceTokenData() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         let dataToken = UUID().asData()
         analytics.registeredForRemoteNotifications(deviceToken: dataToken)
         analytics.track(name: "token check")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         let device = trackEvent?.context?.dictionaryValue
         let token = device?[keyPath: "device.token"] as? String
         XCTAssertTrue(token?.count == 32) // it's a uuid w/o the dashes.  36 becomes 32.
     }
 #endif
-    
+
     func testTrack() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.track(name: "test track")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         XCTAssertTrue(trackEvent?.event == "test track")
         XCTAssertTrue(trackEvent?.type == "track")
     }
-    
+
     func testIdentify() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.identify(userId: "brandon", traits: MyTraits(email: "blah@blah.com"))
-        
+
         let identifyEvent: IdentifyEvent? = outputReader.lastEvent as? IdentifyEvent
         XCTAssertTrue(identifyEvent?.userId == "brandon")
         let traits = identifyEvent?.traits?.dictionaryValue
         XCTAssertTrue(traits?["email"] as? String == "blah@blah.com")
     }
-    
+
     func testUserIdAndTraitsPersistCorrectly() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.identify(userId: "brandon", traits: MyTraits(email: "blah@blah.com"))
-        
+
         let identifyEvent: IdentifyEvent? = outputReader.lastEvent as? IdentifyEvent
         XCTAssertTrue(identifyEvent?.userId == "brandon")
         let traits = identifyEvent?.traits?.dictionaryValue
         XCTAssertTrue(traits?["email"] as? String == "blah@blah.com")
-        
+
         analytics.track(name: "test")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         XCTAssertTrue(trackEvent?.userId == "brandon")
         let trackTraits = trackEvent?.context?.dictionaryValue?["traits"] as? [String: Any]
         XCTAssertNil(trackTraits)
-        
+
         let analyticsTraits: MyTraits? = analytics.traits()
         XCTAssertEqual("blah@blah.com", analyticsTraits?.email)
     }
-    
-    
+
+
     func testScreen() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.screen(title: "screen1", category: "category1")
-        
+
         let screen1Event: ScreenEvent? = outputReader.lastEvent as? ScreenEvent
         XCTAssertTrue(screen1Event?.name == "screen1")
         XCTAssertTrue(screen1Event?.category == "category1")
-        
+
         analytics.screen(title: "screen2", category: "category2", properties: MyTraits(email: "blah@blah.com"))
-        
+
         let screen2Event: ScreenEvent? = outputReader.lastEvent as? ScreenEvent
         XCTAssertTrue(screen2Event?.name == "screen2")
         XCTAssertTrue(screen2Event?.category == "category2")
         let props = screen2Event?.properties?.dictionaryValue
         XCTAssertTrue(props?["email"] as? String == "blah@blah.com")
     }
-    
+
     func testGroup() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.group(groupId: "1234")
-        
+
         let group1Event: GroupEvent? = outputReader.lastEvent as? GroupEvent
         XCTAssertTrue(group1Event?.groupId == "1234")
-        
+
         analytics.group(groupId: "4567", traits: MyTraits(email: "blah@blah.com"))
-        
+
         let group2Event: GroupEvent? = outputReader.lastEvent as? GroupEvent
         XCTAssertTrue(group2Event?.groupId == "4567")
         let props = group2Event?.traits?.dictionaryValue
         XCTAssertTrue(props?["email"] as? String == "blah@blah.com")
     }
-    
+
     func testReset() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.identify(userId: "brandon", traits: MyTraits(email: "blah@blah.com"))
-        
+
         let identifyEvent: IdentifyEvent? = outputReader.lastEvent as? IdentifyEvent
         XCTAssertTrue(identifyEvent?.userId == "brandon")
         let traits = identifyEvent?.traits?.dictionaryValue
         XCTAssertTrue(traits?["email"] as? String == "blah@blah.com")
-        
+
         let currentAnonId = analytics.anonymousId
         let currentUserInfo: UserInfo? = analytics.store.currentState()
-        
+
         analytics.reset()
-        
+
         let newAnonId = analytics.anonymousId
         let newUserInfo: UserInfo? = analytics.store.currentState()
         XCTAssertNotEqual(currentAnonId, newAnonId)
@@ -414,172 +414,172 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertNotEqual(currentUserInfo?.userId, newUserInfo?.userId)
         XCTAssertNotEqual(currentUserInfo?.traits, newUserInfo?.traits)
     }
-    
+
     func testFlush() {
         // Use a specific writekey to this test so we do not collide with other cached items.
         let analytics = Analytics(configuration: Configuration(writeKey: "testFlush_do_not_reuse_this_writekey").flushInterval(9999).flushAt(9999))
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
-        
+
         analytics.identify(userId: "brandon", traits: MyTraits(email: "blah@blah.com"))
-        
+
         let currentBatchCount = analytics.storage.eventFiles(includeUnfinished: true).count
-        
+
         analytics.flush()
         analytics.track(name: "test")
-        
+
         let batches = analytics.storage.eventFiles(includeUnfinished: true)
         let newBatchCount = batches.count
         // 1 new temp file
         XCTAssertTrue(newBatchCount == currentBatchCount + 1, "New Count (\(newBatchCount)) should be \(currentBatchCount) + 1")
     }
-    
+
     func testEnabled() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.track(name: "enabled")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         XCTAssertTrue(trackEvent!.event == "enabled")
-        
+
         outputReader.lastEvent = nil
         analytics.enabled = false
         analytics.track(name: "notEnabled")
-        
+
         let noEvent = outputReader.lastEvent
         XCTAssertNil(noEvent)
-        
+
         analytics.enabled = true
         analytics.track(name: "enabled")
-        
+
         let newEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         XCTAssertTrue(newEvent!.event == "enabled")
     }
-    
+
     func testSetFlushIntervalAfter() {
         let analytics = Analytics(configuration: Configuration(writeKey: "1234"))
         let intervalPolicy = IntervalBasedFlushPolicy(interval: 35)
         analytics.add(flushPolicy: intervalPolicy)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         XCTAssertTrue(intervalPolicy.flushTimer!.interval == 35)
-        
+
         analytics.flushInterval = 60
-        
+
         RunLoop.main.run(until: Date.distantPast)
-        
+
         XCTAssertTrue(intervalPolicy.flushTimer!.interval == 60)
     }
-    
+
     func testSetFlushAtAfter() {
         let analytics = Analytics(configuration: Configuration(writeKey: "1234"))
         let countPolicy = CountBasedFlushPolicy(count: 23)
         analytics.add(flushPolicy: countPolicy)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         XCTAssertTrue(analytics.configuration.values.flushAt == 23)
-        
+
         analytics.flushAt = 1
-        
+
         let event = TrackEvent(event: "blah", properties: nil)
-        
+
         countPolicy.updateState(event: event)
-        
+
         RunLoop.main.run(until: Date.distantPast)
-        
+
         XCTAssertTrue(countPolicy.shouldFlush() == true)
         XCTAssertTrue(analytics.configuration.values.flushAt == 1)
     }
-    
+
     func testPurgeStorage() {
         // Use a specific writekey to this test so we do not collide with other cached items.
         let analytics = Analytics(configuration: Configuration(writeKey: "testFlush_do_not_reuse_this_writekey_either")
             .flushInterval(9999)
             .flushAt(9999)
             .operatingMode(.synchronous))
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
-        
+
         analytics.identify(userId: "brandon", traits: MyTraits(email: "blah@blah.com"))
-        
+
         let currentPendingCount = analytics.pendingUploads!.count
-        
+
         XCTAssertEqual(currentPendingCount, 1)
-        
+
         analytics.flush()
         analytics.track(name: "test")
-        
+
         analytics.flush()
         analytics.track(name: "test")
-        
+
         analytics.flush()
         analytics.track(name: "test")
-        
+
         var newPendingCount = analytics.pendingUploads!.count
         XCTAssertEqual(newPendingCount, 1)
-        
+
         let pending = analytics.pendingUploads!
         analytics.purgeStorage(fileURL: pending.first!)
-        
+
         newPendingCount = analytics.pendingUploads!.count
         XCTAssertEqual(newPendingCount, 0)
-        
+
         analytics.purgeStorage()
         newPendingCount = analytics.pendingUploads!.count
         XCTAssertEqual(newPendingCount, 0)
     }
-    
+
     func testVersion() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.track(name: "whataversion")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         let context = trackEvent?.context?.dictionaryValue
         let eventVersion = context?[keyPath: "library.version"] as? String
         let analyticsVersion = analytics.version()
-        
+
         XCTAssertEqual(eventVersion, analyticsVersion)
     }
-    
+
     class AnyDestination: DestinationPlugin {
         var timeline: Timeline
         let type: PluginType
         let key: String
         var analytics: Analytics?
-        
+
         init(key: String) {
             self.key = key
             self.type = .destination
             self.timeline = Timeline()
         }
     }
-    
+
     // Test to ensure bundled and unbundled integrations are populated correctly
     func testDestinationMetadata() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let mixpanel = AnyDestination(key: "Mixpanel")
         let outputReader = OutputReaderPlugin()
-        
+
         // we want the output reader on the segment plugin
         // cuz that's the only place the metadata is getting added.
         let segmentDest = analytics.find(pluginType: SegmentDestination.self)
         segmentDest?.add(plugin: outputReader)
-        
+
         analytics.add(plugin: mixpanel)
         var settings = Settings(writeKey: "123")
         let integrations = try? JSON([
@@ -595,30 +595,30 @@ final class Analytics_Tests: XCTestCase {
         ])
         settings.integrations = integrations
         analytics.store.dispatch(action: System.UpdateSettingsAction(settings: settings))
-        
+
         waitUntilStarted(analytics: analytics)
-        
-        
+
+
         analytics.track(name: "sampleEvent")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         let metadata = trackEvent?._metadata
-        
+
         XCTAssertEqual(metadata?.bundled, ["Mixpanel"])
         XCTAssertEqual(metadata?.unbundled.sorted(), ["Amplitude", "Customer.io"])
     }
-    
+
     // Test to ensure bundled and active integrations are populated correctly
     func testDestinationMetadataUnbundled() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let mixpanel = AnyDestination(key: "Mixpanel")
         let outputReader = OutputReaderPlugin()
-        
+
         // we want the output reader on the segment plugin
         // cuz that's the only place the metadata is getting added.
         let segmentDest = analytics.find(pluginType: SegmentDestination.self)
         segmentDest?.add(plugin: outputReader)
-        
+
         analytics.add(plugin: mixpanel)
         var settings = Settings(writeKey: "123")
         let integrations = try? JSON([
@@ -634,19 +634,19 @@ final class Analytics_Tests: XCTestCase {
         ])
         settings.integrations = integrations
         analytics.store.dispatch(action: System.UpdateSettingsAction(settings: settings))
-        
+
         waitUntilStarted(analytics: analytics)
-        
-        
+
+
         analytics.track(name: "sampleEvent")
-        
+
         let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
         let metadata = trackEvent?._metadata
-        
+
         XCTAssertEqual(metadata?.bundled, ["Mixpanel"])
         XCTAssertEqual(metadata?.unbundled.sorted(), ["Amplitude", "Customer.io", "dest1"])
     }
-    
+
     func testRequestFactory() {
         let config = Configuration(writeKey: "testSequential").requestFactory { request in
             XCTAssertEqual(request.value(forHTTPHeaderField: "Accept-Encoding"), "gzip")
@@ -666,16 +666,16 @@ final class Analytics_Tests: XCTestCase {
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.track(name: "something")
-        
+
         analytics.flush()
-        
+
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 5))
     }
-    
+
     func testEnrichment() {
         var sourceHit: Bool = false
         let sourceEnrichment: EnrichmentClosure = { event in
@@ -683,72 +683,72 @@ final class Analytics_Tests: XCTestCase {
             sourceHit = true
             return event
         }
-        
+
         var destHit: Bool = true
         let destEnrichment: EnrichmentClosure = { event in
             print("destination enrichment applied")
             destHit = true
             return event
         }
-        
+
         let config = Configuration(writeKey: "testEnrichments")
         let analytics = Analytics(configuration: config)
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
-        
+
         analytics.add(enrichment: sourceEnrichment)
-        
+
         let segment = analytics.find(pluginType: SegmentDestination.self)
         segment?.add(enrichment: destEnrichment)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.track(name: "something")
-        
+
         analytics.flush()
-        
+
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 5))
-        
+
         XCTAssertTrue(sourceHit)
         XCTAssertTrue(destHit)
 
     }
-    
+
     func testSharedInstance() {
         Analytics.firstInstance = nil
-        
+
         let dead = Analytics.shared()
         XCTAssertTrue(dead.isDead)
-        
+
         let alive = Analytics(configuration: Configuration(writeKey: "1234"))
         XCTAssertFalse(alive.isDead)
-        
+
         let shared = Analytics.shared()
         XCTAssertFalse(shared.isDead)
-        
+
         XCTAssertTrue(alive === shared)
-        
+
         let alive2 = Analytics(configuration: Configuration(writeKey: "ABCD"))
         let shared2 = Analytics.shared()
         XCTAssertFalse(alive2 === shared2)
         XCTAssertTrue(shared2 === shared)
-        
+
     }
-    
+
     func testAsyncOperatingMode() throws {
         // Use a specific writekey to this test so we do not collide with other cached items.
         let analytics = Analytics(configuration: Configuration(writeKey: "testFlush_asyncMode")
             .flushInterval(9999)
             .flushAt(9999)
             .operatingMode(.asynchronous))
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
 
         @Atomic var completionCalled = false
-        
+
         // put an event in the pipe ...
         analytics.track(name: "completion test1")
         // flush it, that'll get us an upload going
@@ -756,28 +756,28 @@ final class Analytics_Tests: XCTestCase {
             // verify completion is called.
             completionCalled = true
         }
-        
+
         while !completionCalled {
             RunLoop.main.run(until: Date.distantPast)
         }
-        
+
         XCTAssertTrue(completionCalled)
         XCTAssertEqual(analytics.pendingUploads!.count, 0)
     }
-    
+
     func testSyncOperatingMode() throws {
         // Use a specific writekey to this test so we do not collide with other cached items.
         let analytics = Analytics(configuration: Configuration(writeKey: "testFlush_syncMode")
             .flushInterval(9999)
             .flushAt(9999)
             .operatingMode(.synchronous))
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
 
         @Atomic var completionCalled = false
-        
+
         // put an event in the pipe ...
         analytics.track(name: "completion test1")
         // flush it, that'll get us an upload going
@@ -785,26 +785,26 @@ final class Analytics_Tests: XCTestCase {
             // verify completion is called.
             completionCalled = true
         }
-        
+
         // completion shouldn't be called before flush returned.
         XCTAssertTrue(completionCalled)
         XCTAssertEqual(analytics.pendingUploads!.count, 0)
-        
+
         // put another event in the pipe.
         analytics.track(name: "completion test2")
         analytics.flush()
-        
+
         // flush shouldn't return until all uploads are done, cuz
         // it's running in sync mode.
         XCTAssertEqual(analytics.pendingUploads!.count, 0)
     }
-    
+
     func testFindAll() throws {
         let analytics = Analytics(configuration: Configuration(writeKey: "testFindAll")
             .flushInterval(9999)
             .flushAt(9999)
             .operatingMode(.synchronous))
-        
+
         analytics.add(plugin: ZiggyPlugin())
         analytics.add(plugin: ZiggyPlugin())
         analytics.add(plugin: ZiggyPlugin())
@@ -812,14 +812,14 @@ final class Analytics_Tests: XCTestCase {
         let myDestination = MyDestination()
         myDestination.add(plugin: GooberPlugin())
         myDestination.add(plugin: GooberPlugin())
-        
+
         analytics.add(plugin: myDestination)
-        
+
         waitUntilStarted(analytics: analytics)
-        
+
         let ziggysFound = analytics.findAll(pluginType: ZiggyPlugin.self)
         let goobersFound = myDestination.findAll(pluginType: GooberPlugin.self)
-        
+
         XCTAssertEqual(ziggysFound!.count, 3)
         XCTAssertEqual(goobersFound!.count, 2)
     }

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -95,12 +95,8 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertEqual(myDestination.receivedInitialUpdate, 1)
         XCTAssertEqual(ziggy1.receivedInitialUpdate, 1)
         XCTAssertEqual(ziggy2.receivedInitialUpdate, 1)
-<<<<<<< HEAD
-
-=======
         
         checkIfLeaked(analytics)
->>>>>>> main
     }
 
 
@@ -571,13 +567,8 @@ final class Analytics_Tests: XCTestCase {
         var timeline: Timeline
         let type: PluginType
         let key: String
-<<<<<<< HEAD
-        var analytics: Analytics?
-
-=======
         weak var analytics: Analytics?
-        
->>>>>>> main
+
         init(key: String) {
             self.key = key
             self.type = .destination

--- a/Tests/Segment-Tests/MemoryLeak_Tests.swift
+++ b/Tests/Segment-Tests/MemoryLeak_Tests.swift
@@ -1,6 +1,6 @@
 //
 //  MemoryLeak_Tests.swift
-//  
+//
 //
 //  Created by Brandon Sneed on 10/17/22.
 //
@@ -20,19 +20,19 @@ final class MemoryLeak_Tests: XCTestCase {
 
     func testLeaksVerbose() throws {
         let analytics = Analytics(configuration: Configuration(writeKey: "1234"))
-        
+
         waitUntilStarted(analytics: analytics)
         analytics.track(name: "test")
-        
+
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 1))
-        
+
         let segmentDest = analytics.find(pluginType: SegmentDestination.self)!
         let destMetadata = segmentDest.timeline.find(pluginType: DestinationMetadataPlugin.self)!
         let startupQueue = analytics.find(pluginType: StartupQueue.self)!
-         
+
         let context = analytics.find(pluginType: Context.self)!
-        
-        #if !os(Linux)
+
+        #if !os(Linux) && !os(Windows)
         let deviceToken = analytics.find(pluginType: DeviceToken.self)!
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
@@ -45,7 +45,7 @@ final class MemoryLeak_Tests: XCTestCase {
         let macLifecycle = analytics.find(pluginType: macOSLifecycleEvents.self)!
         let macMonitor = analytics.find(pluginType: macOSLifecycleMonitor.self)!
         #endif
-        
+
         // test that enrichment closure isn't leaked.  was previously a retain loop.
         analytics.add { event in
             return event
@@ -54,9 +54,9 @@ final class MemoryLeak_Tests: XCTestCase {
         analytics.remove(plugin: startupQueue)
         analytics.remove(plugin: segmentDest)
         segmentDest.remove(plugin: destMetadata)
-         
+
         analytics.remove(plugin: context)
-        #if !os(Linux)
+        #if !os(Linux) && !os(Windows)
         analytics.remove(plugin: deviceToken)
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
@@ -75,9 +75,9 @@ final class MemoryLeak_Tests: XCTestCase {
         checkIfLeaked(segmentDest)
         checkIfLeaked(destMetadata)
         checkIfLeaked(startupQueue)
-        
+
         checkIfLeaked(context)
-        #if !os(Linux)
+        #if !os(Linux) && !os(Windows)
         checkIfLeaked(deviceToken)
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
@@ -90,16 +90,16 @@ final class MemoryLeak_Tests: XCTestCase {
         checkIfLeaked(macLifecycle)
         checkIfLeaked(macMonitor)
         #endif
-        
+
         checkIfLeaked(analytics)
     }
-    
+
     func testLeaksSimple() throws {
         let analytics = Analytics(configuration: Configuration(writeKey: "1234"))
-        
+
         waitUntilStarted(analytics: analytics)
         analytics.track(name: "test")
-        
+
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 1))
 
         checkIfLeaked(analytics)

--- a/Tests/Segment-Tests/ObjC_Tests.swift
+++ b/Tests/Segment-Tests/ObjC_Tests.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Sneed on 8/13/21.
 //
 
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 
 import XCTest
 @testable import Segment
@@ -24,60 +24,60 @@ class ObjC_Tests: XCTestCase {
 
      NOTE: These tests only cover non-trivial methods.  Most ObjC methods pass straight through to their swift counterparts
      however, there are some where some data conversion needs to happen in order to be made accessible.
-     
+
      */
 
     func testWrapping() {
         let a = Analytics(configuration: Configuration(writeKey: "WRITE_KEY"))
         let objc = ObjCAnalytics(wrapping: a)
-        
+
         XCTAssertTrue(objc.analytics === a)
     }
-    
+
     func testNonTrivialConfiguration() {
         let config = ObjCConfiguration(writeKey: "WRITE_KEY")
         config.defaultSettings = ["integrations": ["Amplitude": true]]
-        
+
         let defaults = config.defaultSettings
         let integrations = defaults["integrations"] as? [String: Any]
-        
+
         XCTAssertTrue(integrations != nil)
         XCTAssertTrue(integrations?["Amplitude"] as? Bool == true)
     }
-    
+
     func testNonTrivialAnalytics() {
         Storage.hardSettingsReset(writeKey: "WRITE_KEY")
         let config = ObjCConfiguration(writeKey: "WRITE_KEY")
         config.defaultSettings = ["integrations": ["Amplitude": true]]
-        
+
         let analytics = ObjCAnalytics(configuration: config)
         analytics.reset()
-        
+
         analytics.identify(userId: "testPerson", traits: ["email" : "blah@blah.com"])
-        
+
         waitUntilStarted(analytics: analytics.analytics)
-        
+
         let settings = analytics.settings()
         let integrations = settings?["integrations"] as? [String: Any]
-        
+
         XCTAssertTrue(integrations != nil)
         XCTAssertTrue(integrations?["Amplitude"] as? Bool == true)
-        
+
         let traits = analytics.traits()
         XCTAssertTrue(traits != nil)
         XCTAssertTrue(traits?["email"] as? String == "blah@blah.com")
-        
+
         let userId = analytics.userId
         XCTAssertTrue(userId == "testPerson")
     }
-    
+
     func testTraitsAndUserIdOptionality() {
         let config = ObjCConfiguration(writeKey: "WRITE_KEY")
         let analytics = ObjCAnalytics(configuration: config)
         analytics.reset()
-        
+
         analytics.identify(userId: nil, traits: ["email" : "blah@blah.com"])
-        
+
         waitUntilStarted(analytics: analytics.analytics)
         let userId = analytics.userId
         XCTAssertNil(userId)
@@ -85,66 +85,66 @@ class ObjC_Tests: XCTestCase {
         XCTAssertTrue(traits != nil)
         XCTAssertTrue(traits?["email"] as? String == "blah@blah.com")
     }
-    
+
     func testObjCMiddlewares() {
         var sourceHit: Bool = false
         var destHit: Bool = false
-        
+
         Storage.hardSettingsReset(writeKey: "WRITE_KEY")
-        
+
         let config = ObjCConfiguration(writeKey: "WRITE_KEY")
         let analytics = ObjCAnalytics(configuration: config)
         analytics.analytics.storage.hardReset(doYouKnowHowToUseThis: true)
-        
+
         analytics.reset()
-        
+
         let outputReader = OutputReaderPlugin()
         analytics.analytics.add(plugin: outputReader)
-        
+
         let sourcePlugin = ObjCBlockPlugin { event in
             print("source enrichment applied")
             sourceHit = true
             return event
         }
         analytics.add(plugin: sourcePlugin)
-        
+
         let destPlugin = ObjCBlockPlugin { event in
             print("destination enrichment applied")
             destHit = true
             return event
         }
         analytics.add(plugin: destPlugin, destinationKey: "Segment.io")
-        
+
         waitUntilStarted(analytics: analytics.analytics)
-        
+
         analytics.identify(userId: "batman")
-        
+
         analytics.flush()
-        
+
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 5))
-        
+
         XCTAssertTrue(sourceHit)
         XCTAssertTrue(destHit)
-        
+
         let lastEvent = outputReader.lastEvent
         XCTAssertTrue(lastEvent is IdentifyEvent)
         XCTAssertTrue((lastEvent as! IdentifyEvent).userId == "batman")
     }
-    
+
     func testObjCDictionaryPassThru() {
         Storage.hardSettingsReset(writeKey: "WRITE_KEY2")
-        
+
         let config = ObjCConfiguration(writeKey: "WRITE_KEY2")
         let analytics = ObjCAnalytics(configuration: config)
         analytics.analytics.storage.hardReset(doYouKnowHowToUseThis: true)
-        
+
         analytics.reset()
-        
+
         let outputReader = OutputReaderPlugin()
         analytics.analytics.add(plugin: outputReader)
-        
+
         waitUntilStarted(analytics: analytics.analytics)
-        
+
         let dict = [
             "ancientAliens": [
                 "guy1": "hair guy",
@@ -152,7 +152,7 @@ class ObjC_Tests: XCTestCase {
                 "guy3": "old bald guy",
                 "guy4": 4] as [String : Any],
             "channel": "hIsToRy cHaNnEL"] as [String : Any]
-        
+
         analytics.track(name: "test", properties: dict)
         RunLoop.main.run(until: Date.distantPast)
         let trackEvent = outputReader.lastEvent as? TrackEvent
@@ -160,7 +160,7 @@ class ObjC_Tests: XCTestCase {
         XCTAssertNotNil(trackEvent)
         XCTAssertTrue(props?.count == 2)
         XCTAssertTrue((props?["ancientAliens"] as? [String: Any])?.count == 4)
-        
+
         analytics.identify(userId: "test", traits: dict)
         RunLoop.main.run(until: Date.distantPast)
         let identifyEvent = outputReader.lastEvent as? IdentifyEvent
@@ -176,7 +176,7 @@ class ObjC_Tests: XCTestCase {
         XCTAssertNotNil(identifyEvent2)
         XCTAssertTrue(traits2?.count == 2)
         XCTAssertTrue((traits2?["ancientAliens"] as? [String: Any])?.count == 4)
-        
+
         analytics.screen(title: "blah", category: nil, properties: dict)
         RunLoop.main.run(until: Date.distantPast)
         let screenEvent = outputReader.lastEvent as? ScreenEvent
@@ -184,7 +184,7 @@ class ObjC_Tests: XCTestCase {
         XCTAssertNotNil(screenEvent)
         XCTAssertTrue(props2?.count == 2)
         XCTAssertTrue((props2?["ancientAliens"] as? [String: Any])?.count == 4)
-        
+
         analytics.group(groupId: "123", traits: dict)
         RunLoop.main.run(until: Date.distantPast)
         let groupEvent = outputReader.lastEvent as? GroupEvent

--- a/Tests/Segment-Tests/Support/TestUtilities.swift
+++ b/Tests/Segment-Tests/Support/TestUtilities.swift
@@ -27,11 +27,11 @@ struct MyTraits: Codable {
 class GooberPlugin: EventPlugin {
     let type: PluginType
     var analytics: Analytics?
-    
+
     init() {
         self.type = .enrichment
     }
-    
+
     func identify(event: IdentifyEvent) -> IdentifyEvent? {
         var newEvent = IdentifyEvent(existing: event)
         newEvent.userId = "goober"
@@ -43,30 +43,30 @@ class ZiggyPlugin: EventPlugin {
     let type: PluginType
     var analytics: Analytics?
     var receivedInitialUpdate: Int = 0
-    
+
     var completion: (() -> Void)?
-    
+
     required init() {
         self.type = .enrichment
     }
-    
+
     func update(settings: Settings, type: UpdateType) {
         if type == .initial { receivedInitialUpdate += 1 }
     }
-    
+
     func identify(event: IdentifyEvent) -> IdentifyEvent? {
         var newEvent = IdentifyEvent(existing: event)
         newEvent.userId = "ziggy"
         return newEvent
         //return nil
     }
-    
+
     func shutdown() {
         completion?()
     }
 }
 
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 
 @objc(SEGMyDestination)
 public class ObjCMyDestination: NSObject, ObjCPlugin, ObjCPluginShim {
@@ -81,10 +81,10 @@ class MyDestination: DestinationPlugin {
     let key: String
     var analytics: Analytics?
     let trackCompletion: (() -> Bool)?
-    
+
     let disabled: Bool
     var receivedInitialUpdate: Int = 0
-    
+
     init(disabled: Bool = false, trackCompletion: (() -> Bool)? = nil) {
         self.key = "MyDestination"
         self.type = .destination
@@ -92,7 +92,7 @@ class MyDestination: DestinationPlugin {
         self.trackCompletion = trackCompletion
         self.disabled = disabled
     }
-    
+
     func update(settings: Settings, type: UpdateType) {
         if type == .initial { receivedInitialUpdate += 1 }
         if disabled == false {
@@ -100,7 +100,7 @@ class MyDestination: DestinationPlugin {
             analytics?.manuallyEnableDestination(plugin: self)
         }
     }
-    
+
     func track(event: TrackEvent) -> TrackEvent? {
         var returnEvent: TrackEvent? = event
         if let completion = trackCompletion {
@@ -115,14 +115,14 @@ class MyDestination: DestinationPlugin {
 class OutputReaderPlugin: Plugin {
     let type: PluginType
     var analytics: Analytics?
-    
+
     var events = [RawEvent]()
     var lastEvent: RawEvent? = nil
-    
+
     init() {
         self.type = .after
     }
-    
+
     func execute<T>(event: T?) -> T? where T : RawEvent {
         lastEvent = event
         if let t = lastEvent as? TrackEvent {
@@ -154,28 +154,28 @@ extension XCTestCase {
     }
 }
 
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 
 class BlockNetworkCalls: URLProtocol {
     var initialURL: URL? = nil
     override class func canInit(with request: URLRequest) -> Bool {
-        
+
         return true
     }
-    
+
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
     }
-    
+
     override var cachedResponse: CachedURLResponse? { return nil }
-    
+
     override func startLoading() {
         client?.urlProtocol(self, didReceive: HTTPURLResponse(url: URL(string: "http://api.segment.com")!, statusCode: 200, httpVersion: nil, headerFields: ["blocked": "true"])!, cacheStoragePolicy: .notAllowed)
         client?.urlProtocolDidFinishLoading(self)
     }
-    
+
     override func stopLoading() {
-        
+
     }
 }
 

--- a/Tests/Segment-Tests/WindowsVendorSystem_Tests.swift
+++ b/Tests/Segment-Tests/WindowsVendorSystem_Tests.swift
@@ -4,35 +4,35 @@ import XCTest
 #if os(Windows)
 
 final class WindowsVendorSystem_Tests: XCTestCase {
-	func testScreenSizeReturnsNonEmpty() {
-		let system = WindowsVendorSystem()
+    func testScreenSizeReturnsNonEmpty() {
+        let system = WindowsVendorSystem()
 
-		let screen = system.screenSize
+        let screen = system.screenSize
 
-		XCTAssertNotEqual(screen.width, 0)
-		XCTAssertNotEqual(screen.height, 0)
-	}
+        XCTAssertNotEqual(screen.width, 0)
+        XCTAssertNotEqual(screen.height, 0)
+    }
 
-	func testNameReturnsNonEmpty() {
-		let system = WindowsVendorSystem()
+    func testNameReturnsNonEmpty() {
+        let system = WindowsVendorSystem()
 
-		let name = system.systemName
+        let name = system.systemName
 
-		XCTAssertNotEqual(name, "unknown")
-	}
+        XCTAssertNotEqual(name, "unknown")
+    }
 
-	func testVersionNumberIsWellFormatted() {
-		let system = WindowsVendorSystem()
+    func testVersionNumberIsWellFormatted() {
+        let system = WindowsVendorSystem()
 
-		let version = system.systemVersion
+        let version = system.systemVersion
 
-		let components = version.split(separator: ".")
+        let components = version.split(separator: ".")
 
-		XCTAssertEqual(components.count, 3)
+        XCTAssertEqual(components.count, 3)
 
-		// Ensure that the version components are all numeric
-		XCTAssertTrue(components.allSatisfy({ Int($0) != nil }))
-	}
+        // Ensure that the version components are all numeric
+        XCTAssertTrue(components.allSatisfy({ Int($0) != nil }))
+    }
 }
 
 #endif

--- a/Tests/Segment-Tests/WindowsVendorSystem_Tests.swift
+++ b/Tests/Segment-Tests/WindowsVendorSystem_Tests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Segment
+
+#if os(Windows)
+
+final class WindowsVendorSystem_Tests: XCTestCase {
+	func testScreenSizeReturnsNonEmpty() {
+		let system = WindowsVendorSystem()
+
+		let screen = system.screenSize
+
+		XCTAssertNotEqual(screen.width, 0)
+		XCTAssertNotEqual(screen.height, 0)
+	}
+
+	func testNameReturnsNonEmpty() {
+		let system = WindowsVendorSystem()
+
+		let name = system.systemName
+
+		XCTAssertNotEqual(name, "unknown")
+	}
+
+	func testVersionNumberIsWellFormatted() {
+		let system = WindowsVendorSystem()
+
+		let version = system.systemVersion
+
+		let components = version.split(separator: ".")
+
+		XCTAssertEqual(components.count, 3)
+
+		// Ensure that the version components are all numeric
+		XCTAssertTrue(components.allSatisfy({ Int($0) != nil }))
+	}
+}
+
+#endif


### PR DESCRIPTION
This should build (but not completely test) on Windows. I would label it as experimental since it does run, but will likely have issues that need to be ironed out. As mentioned in https://github.com/segmentio/analytics-swift/issues/279 a pluggable networking stack will help us work around the problems with `URLSession` but I figured I'd post this as a mergable artifact. 

Changes
- This adds an `.editorconfig` so that style can be kept consistent across those who are using Xcode and other editors (I don't know if theseis the right settings, but I tried to match what was there)
- Add a new `WindowsVendorSystem` with system calls to populate various bits of information where possible.
- Update `#if` blocks around the codebase to allow for building on Windows
- Add entry for Windows CI to ensure that the codebase stays buildable on Windows.

I apologize for the trimming of the whitespace, I can try to rebuild this PR if it's an annoyance, but it seems that VS Code trims whitespace by default and this is where I ended up.