### PR TITLE
Change to using a single date formatter and update unit tests.

### DIFF
--- a/Sources/Segment/Utilities/iso8601.swift
+++ b/Sources/Segment/Utilities/iso8601.swift
@@ -27,14 +27,3 @@ internal extension String {
         return SegmentISO8601DateFormatter.shared.date(from: self)
     }
 }
-
-extension DateFormatter {
-    static let iso8601: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter
-    }()
-}


### PR DESCRIPTION
https://github.com/segmentio/analytics-swift/issues/284

As described in the ticket above, the two date formatters in the library didn't match up in the strings they produce. I've consolidated to a single date formatter using the string format like:
"2023-12-14T16:03:14.300Z"

The format used by the other date formatter, that I've removed, was: 
"2023-12-13T23:26:37.091+0000"

_Testing_
* Changed a unit test to support this single date formatter.
* Did some initial testing in our own app by bringing the changed analytics-swift package in and looking at Segment debugger output for dates with Codable and non-Codable interfaces. Both now are the same in my tests.