### PR TITLE
Fix: Get config from system state in `IntervalPolicy`

### DIFF
--- a/Sources/Segment/Utilities/Policies/IntervalBasedFlushPolicy.swift
+++ b/Sources/Segment/Utilities/Policies/IntervalBasedFlushPolicy.swift
@@ -39,7 +39,8 @@ public class IntervalBasedFlushPolicy: FlushPolicy,
         self.analytics?.store.subscribe(self, initialState: true) { [weak self] (state: System) in
             guard let self = self else { return }
             guard let a = self.analytics else { return }
-            self.flushTimer = QueueTimer(interval: a.configuration.values.flushInterval) { [weak self] in
+            guard let system: System = a.store.currentState() else { return }
+            self.flushTimer = QueueTimer(interval: system.configuration.values.flushInterval) { [weak self] in
                 self?.analytics?.flush()
             }
         }


### PR DESCRIPTION
- Prevents a crash where  initial state is attempting to be accessed prior to completion. 
- #286 