### PR TITLE
Multiple instance write key

### DIFF
--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -28,6 +28,7 @@ public class Analytics {
     
     static internal let deadInstance = "DEADINSTANCE"
     static internal weak var firstInstance: Analytics? = nil
+    @Atomic static internal var activeWriteKeys = [String]()
     
     /**
      This method isn't a traditional singleton implementation.  It's provided here
@@ -58,6 +59,12 @@ public class Analytics {
     /// - Parameters:
     ///    - configuration: The configuration to use
     public init(configuration: Configuration) {
+        if Self.isActiveWriteKey(configuration.values.writeKey) {
+            fatalError("Cannot initialize multiple instances of Analytics with the same write key")
+        } else {
+            Self.addActiveWriteKey(configuration.values.writeKey)
+        }
+        
         store = Store()
         storage = Storage(store: self.store, writeKey: configuration.values.writeKey)
         timeline = Timeline()
@@ -72,6 +79,10 @@ public class Analytics {
         
         // Get everything running
         platformStartup()
+    }
+    
+    deinit {
+        Self.removeActiveWriteKey(configuration.values.writeKey)
     }
     
     internal func process<E: RawEvent>(incomingEvent: E) {
@@ -428,10 +439,25 @@ extension Analytics {
             Self.firstInstance = self
         }
     }
-        
+    
     /// Determines if an instance is dead.
     internal var isDead: Bool {
         return configuration.values.writeKey == Self.deadInstance
+    }
+    
+    /// Manage active writekeys.  It's wrapped in @atomic
+    internal static func isActiveWriteKey(_ writeKey: String) -> Bool {
+        Self.activeWriteKeys.contains(writeKey)
+    }
+    
+    internal static func addActiveWriteKey(_ writeKey: String) {
+        Self.activeWriteKeys.append(writeKey)
+    }
+    
+    internal static func removeActiveWriteKey(_ writeKey: String) {
+        Self.activeWriteKeys.removeAll { key in
+            writeKey == key
+        }
     }
 }
 

--- a/Sources/Segment/Configuration.swift
+++ b/Sources/Segment/Configuration.swift
@@ -25,10 +25,6 @@ public enum OperatingMode {
 // MARK: - Internal Configuration
 
 public class Configuration {
-    
-    internal let writeKeyLock: NSLock  = NSLock()
-    static var activeWriteKeys = [String]()
-    
     internal struct Values {
         var writeKey: String
         var application: Any? = nil
@@ -63,17 +59,6 @@ public class Configuration {
         ])
         
         self.defaultSettings(settings)
-        
-        checkActiveWriteKeys(writeKey: writeKey)
-    }
-    
-    deinit {
-        writeKeyLock.lock()
-        defer { writeKeyLock.unlock() }
-        
-        if let index = Configuration.activeWriteKeys.firstIndex(of: values.writeKey) {
-            Configuration.activeWriteKeys.remove(at: index)
-        }
     }
 }
 
@@ -247,20 +232,6 @@ public extension Configuration {
         values.jsonNonConformingNumberStrategy = strategy
         JSON.jsonNonConformingNumberStrategy = values.jsonNonConformingNumberStrategy
         return self
-    }
-    
-    func checkActiveWriteKeys(writeKey: String) {
-        writeKeyLock.lock()
-        
-        defer {
-            writeKeyLock.unlock()
-        }
-        
-        if Configuration.activeWriteKeys.contains(writeKey) {
-            fatalError("Cannot initialize multiple instances of Analytics with the same write key")
-        } else {
-            Configuration.activeWriteKeys.append(writeKey)
-        }
     }
 }
 

--- a/Sources/Segment/ObjC/ObjCPlugin.swift
+++ b/Sources/Segment/ObjC/ObjCPlugin.swift
@@ -30,7 +30,7 @@ public class ObjCSegmentMixpanel: NSObject, ObjCPlugin, ObjCPluginShim {
 @objc(SEGEventPlugin)
 public class ObjCEventPlugin: NSObject, EventPlugin, ObjCPlugin {
     public var type: PluginType = .enrichment
-    public var analytics: Analytics? = nil
+    public weak var analytics: Analytics? = nil
     
     @objc(executeEvent:)
     public func execute(event: ObjCRawEvent?) -> ObjCRawEvent? {

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -13,6 +13,9 @@ final class Analytics_Tests: XCTestCase {
         
         let traits = MyTraits(email: "brandon@redf.net")
         analytics.identify(userId: "brandon", traits: traits)
+        
+        waitUntilStarted(analytics: analytics)
+        checkIfLeaked(analytics)
     }
     
     func testPluginConfigure() {
@@ -28,6 +31,8 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertNotNil(ziggy.analytics)
         XCTAssertNotNil(myDestination.analytics)
         XCTAssertNotNil(goober.analytics)
+        
+        waitUntilStarted(analytics: analytics)
     }
     
     func testPluginRemove() {
@@ -91,6 +96,7 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertEqual(ziggy1.receivedInitialUpdate, 1)
         XCTAssertEqual(ziggy2.receivedInitialUpdate, 1)
         
+        checkIfLeaked(analytics)
     }
 
     
@@ -160,6 +166,7 @@ final class Analytics_Tests: XCTestCase {
         
         XCTAssertTrue(anonId != "")
         XCTAssertTrue(anonId.count == 36) // it's a UUID y0.
+        waitUntilStarted(analytics: analytics)
     }
     
     func testContext() {

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -567,7 +567,7 @@ final class Analytics_Tests: XCTestCase {
         var timeline: Timeline
         let type: PluginType
         let key: String
-        var analytics: Analytics?
+        weak var analytics: Analytics?
         
         init(key: String) {
             self.key = key

--- a/Tests/Segment-Tests/Storage_Tests.swift
+++ b/Tests/Segment-Tests/Storage_Tests.swift
@@ -56,7 +56,7 @@ class StorageTests: XCTestCase {
         
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
-        
+        analytics.waitUntilStarted()
         // this will crash if it fails.
         let j = try! JSON(jsonSettings)
         analytics.storage.write(.settings, value: j)
@@ -70,7 +70,7 @@ class StorageTests: XCTestCase {
 
     func testBasicWriting() throws {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
-        
+        analytics.waitUntilStarted()
         analytics.identify(userId: "brandon", traits: MyTraits(email: "blah@blah.com"))
         
         let userInfo: UserInfo? = analytics.store.currentState()
@@ -90,6 +90,8 @@ class StorageTests: XCTestCase {
     func testEventWriting() throws {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
+        
+        analytics.waitUntilStarted()
         
         var event = IdentifyEvent(userId: "brandon1", traits: try! JSON(with: MyTraits(email: "blah@blah.com")))
         analytics.storage.write(.events, value: event)
@@ -133,6 +135,8 @@ class StorageTests: XCTestCase {
     func testFilePrepAndFinish() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         analytics.storage.hardReset(doYouKnowHowToUseThis: true)
+        
+        analytics.waitUntilStarted()
         
         var event = IdentifyEvent(userId: "brandon1", traits: try! JSON(with: MyTraits(email: "blah@blah.com")))
         analytics.storage.write(.events, value: event)

--- a/Tests/Segment-Tests/Support/TestUtilities.swift
+++ b/Tests/Segment-Tests/Support/TestUtilities.swift
@@ -26,7 +26,7 @@ struct MyTraits: Codable {
 
 class GooberPlugin: EventPlugin {
     let type: PluginType
-    var analytics: Analytics?
+    weak var analytics: Analytics?
     
     init() {
         self.type = .enrichment
@@ -41,7 +41,7 @@ class GooberPlugin: EventPlugin {
 
 class ZiggyPlugin: EventPlugin {
     let type: PluginType
-    var analytics: Analytics?
+    weak var analytics: Analytics?
     var receivedInitialUpdate: Int = 0
     
     var completion: (() -> Void)?
@@ -79,7 +79,7 @@ class MyDestination: DestinationPlugin {
     var timeline: Timeline
     let type: PluginType
     let key: String
-    var analytics: Analytics?
+    weak var analytics: Analytics?
     let trackCompletion: (() -> Bool)?
     
     let disabled: Bool
@@ -114,7 +114,7 @@ class MyDestination: DestinationPlugin {
 
 class OutputReaderPlugin: Plugin {
     let type: PluginType
-    var analytics: Analytics?
+    weak var analytics: Analytics?
     
     var events = [RawEvent]()
     var lastEvent: RawEvent? = nil


### PR DESCRIPTION
-add check in `Analytics` to prevent multiple instances with the same `write-key` from being initialized at the same time