### PR TITLE
Update Sorvan to 1.1.1 for Swift 5.9

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/segmentio/Sovran-Swift.git",
       "state" : {
-        "revision" : "64f3b5150c282a34af4578188dce2fd597e600e3",
-        "version" : "1.1.0"
+        "revision" : "a342b905f6baa64499cabdf61ccc185ec476b7b2",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/segmentio/sovran-swift.git", from: "1.1.0"),
+        .package(url: "https://github.com/segmentio/sovran-swift.git", from: "1.1.1"),
         .package(url: "https://github.com/segmentio/jsonsafeencoder-swift.git", from: "1.0.0")
     ],
     targets: [


### PR DESCRIPTION
Hi 👋 

In version [1.5.4](https://github.com/segmentio/analytics-swift/releases/tag/1.5.4), Sorvan was updated to 1.1.1, but `Package@swift-5.9.swift` was not changed. As a result, the version of Sorvan is still 1.1.0 in `Package.resolved`, so this PR will fix that.