### PR TITLE
Updated storage directory selection logic

### DIFF
--- a/Sources/Segment/Utilities/Utils.swift
+++ b/Sources/Segment/Utilities/Utils.swift
@@ -70,10 +70,10 @@ extension Optional: Flattenable {
 }
 
 internal func eventStorageDirectory(writeKey: String) -> URL {
-    #if os(tvOS) || os(macOS)
-    let searchPathDirectory = FileManager.SearchPathDirectory.cachesDirectory
-    #else
+    #if (os(iOS) || os(watchOS)) && !targetEnvironment(macCatalyst)
     let searchPathDirectory = FileManager.SearchPathDirectory.documentDirectory
+    #else
+    let searchPathDirectory = FileManager.SearchPathDirectory.cachesDirectory
     #endif
     
     let urls = FileManager.default.urls(for: searchPathDirectory, in: .userDomainMask)


### PR DESCRIPTION
The logic for selecting the event storage directory has been updated. Previously, it was based on whether the operating system was tvOS or macOS. Now, it's determined by whether the OS is iOS or watchOS and not running in a Mac Catalyst environment. This change should improve data handling across different platforms.

- iOS/watchOS use the .documents search path.
- Everything else (macOS, linux, windows, catalyst, etc) will use the .caches search path.