### PR TITLE
fix: compare default `apiHost` with `apiHost` configuration instead of `writeKey`

### DIFF
--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -81,7 +81,7 @@ public class SegmentDestination: DestinationPlugin, Subscriber, FlushCompletion 
          */
         // if customer specifies a different apiHost (ie: eu1.segmentapis.com) at app.segment.com ...
         if let host = segmentInfo?[Self.Constants.apiHost.rawValue] as? String, host.isEmpty == false {
-            if host != analytics.configuration.values.writeKey {
+            if host != analytics.configuration.values.apiHost {
                 analytics.configuration.values.apiHost = host
                 httpClient = HTTPClient(analytics: analytics)
             }


### PR DESCRIPTION
I just found this bug that when I override the `apiHost` through the configuration it is set back to the default host once the settings are fetched. Event though the settings don't have an overridden host.

That is because you compare the `host` against `configuration.values.writeKey` instead of `configuration.values.apiHost`.

This fixes that.