### PR TITLE
Remove privacy domains

### DIFF
--- a/Sources/Segment/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Segment/Resources/PrivacyInfo.xcprivacy
@@ -4,11 +4,6 @@
 <dict>
 	<key>NSPrivacyTracking</key>
 	<false/>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>cdn-settings.segment.com</string>
-		<string>api.segment.io</string>
-	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
- Fixes #315 

From: https://developer.apple.com/app-store/app-privacy-details/#user-tracking

**“Tracking” refers to linking data collected from your app about a particular end-user or device, such as a user ID, device ID, or profile, with Third-Party Data for targeted advertising or advertising measurement purposes, or sharing data collected from your app about a particular end-user or device with a data broker.**

We do not collect data for advertising or measurement purposes, and we are not a data broker.  These decisions are up to the user and marked as such in their own apps.