### PR TITLE
fix: Atomic increment is now performed within one enqueued operation

### DIFF
--- a/Examples/other_plugins/IDFACollection.swift
+++ b/Examples/other_plugins/IDFACollection.swift
@@ -77,10 +77,15 @@ class IDFACollection: Plugin {
 extension IDFACollection: iOSLifecycle {
     func applicationDidBecomeActive(application: UIApplication?) {
         let status = ATTrackingManager.trackingAuthorizationStatus
-        if status == .notDetermined && !alreadyAsked {
-            // we don't know, so should ask the user.
-            alreadyAsked = true
-            askForPermission()
+
+        _alreadyAsked.withValue { alreadyAsked in
+            if status == .notDetermined && !alreadyAsked {
+                // we don't know, so should ask the user.
+                alreadyAsked = true
+                DispatchQueue.main.async {
+                    askForPermission()
+                }
+            }
         }
     }
 }

--- a/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
@@ -76,6 +76,9 @@ internal class iOSVendorSystem: VendorSystem {
         // BKS: It was discovered that on some platforms there can be a delay in retrieval.
         // It has to be fetched on the main thread, so we've spun it off
         // async and cache it when it comes back.
+        // Note that due to how the `@Atomic` wrapper works, this boolean check may pass twice or more
+        // times before the value is updated, fetching the user agent multiple times as the result.
+        // This is not a big deal as the `userAgent` value is not expected to change often.
         if Self.asyncUserAgent == nil {
             DispatchQueue.main.async {
                 Self.asyncUserAgent = WKWebView().value(forKey: "userAgent") as? String
@@ -248,6 +251,9 @@ internal class MacOSVendorSystem: VendorSystem {
         // BKS: It was discovered that on some platforms there can be a delay in retrieval.
         // It has to be fetched on the main thread, so we've spun it off
         // async and cache it when it comes back.
+        // Note that due to how the `@Atomic` wrapper works, this boolean check may pass twice or more
+        // times before the value is updated, fetching the user agent multiple times as the result.
+        // This is not a big deal as the `userAgent` value is not expected to change often.
         if Self.asyncUserAgent == nil {
             DispatchQueue.main.async {
                 Self.asyncUserAgent = WKWebView().value(forKey: "userAgent") as? String

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -116,7 +116,9 @@ public class SegmentDestination: DestinationPlugin, Subscriber, FlushCompletion 
         guard let storage = self.storage else { return }
         // Send Event to File System
         storage.write(.events, value: event)
-        eventCount += 1
+        self._eventCount.withValue { count in
+            count += 1
+        }
     }
     
     public func flush() {

--- a/Sources/Segment/Utilities/Atomic.swift
+++ b/Sources/Segment/Utilities/Atomic.swift
@@ -29,4 +29,12 @@ public class Atomic<T> {
         get { return queue.sync { return value } }
         set { queue.sync { value = newValue } }
     }
+
+    @discardableResult
+    public func withValue(_ operation: (inout T) -> Void) -> T {
+        queue.sync {
+            operation(&self.value)
+            return self.value
+        }
+    }
 }

--- a/Sources/Segment/Utilities/Policies/CountBasedFlushPolicy.swift
+++ b/Sources/Segment/Utilities/Policies/CountBasedFlushPolicy.swift
@@ -37,7 +37,9 @@ public class CountBasedFlushPolicy: FlushPolicy {
     }
     
    public func updateState(event: RawEvent) {
-        count += 1
+       _count.withValue { value in
+           value += 1
+       }
     }
     
     public func reset() {

--- a/Sources/Segment/Version.swift
+++ b/Sources/Segment/Version.swift
@@ -15,4 +15,4 @@
 // Use release.sh's automation.
 
 // BREAKING.FEATURE.FIX
-internal let __segment_version = "1.5.9"
+internal let __segment_version = "1.5.10"

--- a/Tests/Segment-Tests/Atomic_Tests.swift
+++ b/Tests/Segment-Tests/Atomic_Tests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Segment
+
+final class Atomic_Tests: XCTestCase {
+
+    func testAtomicIncrement() {
+
+        @Atomic var counter = 0
+
+        DispatchQueue.concurrentPerform(iterations: 1000) { _ in
+            // counter += 1 would fail, because it is expanded to:
+            // `let oldValue = queue.sync { counter }`
+            // `queue.sync { counter = oldValue + 1 }`
+            // And the threads are free to suspend in between the two calls to `queue.sync`.
+
+            _counter.withValue { value in
+                value += 1
+            }
+        }
+
+        XCTAssertEqual(counter, 1000)
+    }
+}


### PR DESCRIPTION
The current implementation of the `Atomic` property wrapper is sometimes used in a way that results in race conditions.

When used like this:
```swift
@Atomic var counter: Int = 0
counter += 1
```
It doesn't result in correct atomic operations. This is also applicable to operations that read the Atomic value, followed by a write based on the read value.

![Screenshot 2024-04-22 at 12 58 28 PM](https://github.com/segmentio/analytics-swift/assets/15340382/e4258df0-d8a1-4027-8229-e3ebb142d8bd)

This is because the line `counter += 1` is expanded as:
```swift
let oldValue = queue.sync { counter }
queue.sync { counter = oldValue + 1 }
```
And there is nothing preventing a thread to suspend in the middle of these two operations, so that multiple calls to a function containing an increment could be linearized as:
```
Thread 1: var x = read counter: 0
Thread 2: var y = read counter: 0
Thread 2: counter = y + 1 = 1
Thread 1: counter = x + 1 = 1
// Two threads trying to increment, but we lost one.
```

This PR fixes a couple of such cases, by adding a new method to the `Atomic` property wrapper that allows for more complex operations. Using the new method instead of directly performing the increment fixes the issue:

![Screenshot 2024-04-22 at 12 58 53 PM](https://github.com/segmentio/analytics-swift/assets/15340382/9778f21a-e697-422b-8135-05f9eb8ec437)

This PR also adds a unit test just for the Atomic wrapper that demonstrates the issue.

There are another couple cases that I left as they are since I'm not so sure how to fix them:
- The `QueueTimer` `suspend` and `resume` functions first read the `state`, then write it if needed, then suspend the timer. This could result in the `suspend` function being called multiple times, same for the `resume`. I think the best solution would be to protect `state` and `timer` using the same queue.
-  In `Analytics.swift:62` we check `isActiveWriteKey` then in line 67 we add the active key. This is also a data race, that could result in the active key added to `activeWriteKeys` multiple times. Maybe `activeWriteKeys` should be a `Set` to avoid duplicates?
- In the `ConnectionMonitor`, the `connectionStatus` is updated every five minutes. Even if the usage of `Atomic` is flawed, I left it as is because of the large amount of time between calls.

In general, I suggest to get rid of the `@Atomic` wrapper altogether, and just use `DispatchQueue`s directly. It will likely result in less queues being managed by the system, and less tricky mistakes like this one. Even better if you move to `actor` 😄 
