### PR TITLE
Revert `swift-tools-version` to 5.8 (Builds with Xcode 14.x)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Segment/Version.swift
+++ b/Sources/Segment/Version.swift
@@ -15,4 +15,4 @@
 // Use release.sh's automation.
 
 // BREAKING.FEATURE.FIX
-internal let __segment_version = "1.5.9"
+internal let __segment_version = "1.5.10"


### PR DESCRIPTION
We are transitioning all projects to Xcode 15.x but have not yet completed this work. The prior change to `5.9` requires Xcode 15.x, specifically preventing building with Xcode 14.x.

It doesn't appear that 5.9 is strictly needed at this point (no 5.9 SPM features employed).

Note that we had been working with the pinned version of 1.5.5, but this no longer builds because of this PR: https://github.com/segmentio/analytics-swift/pull/329/files

