### PR TITLE
Fix memory leak when processing locally stored events

### DIFF
--- a/Sources/Segment/Version.swift
+++ b/Sources/Segment/Version.swift
@@ -15,4 +15,4 @@
 // Use release.sh's automation.
 
 // BREAKING.FEATURE.FIX
-internal let __segment_version = "1.5.9"
+internal let __segment_version = "1.5.10"


### PR DESCRIPTION
We have noticed high RAM usage when the host application is used offline or behind a firewall that blocks the Segment API/CDN domains. The SDK would attempt to upload the data unsuccessfully and retry. On each attempt it would iterate through the locally stored files and read them into memory.

In some cases this caused our application to crash due to OOM.

The Swift code looks correct, and in theory all `Data` instances should deallocate after processing a file.  But since the `Data` is actually [a bridge](https://developer.apple.com/documentation/foundation/data) to the `NSData` class, and `NSData` is an Objecive-C class, some manual memory management is required.

## Proposed fix

Use autorelease pools to explicitly release allocated memory on each iteration to avoid unnecessary memory consumption.

This fixes the immediate problem we are experiencing. We haven't yet gone through other functions or investigated whether there are other cases where autorelease pools could be used. 

## Context
- https://forums.swift.org/t/the-role-of-autoreleasepool-in-swift-and-thoughts-about-memory-management-in-swift/52976
- https://stackoverflow.com/questions/25860942/is-it-necessary-to-use-autoreleasepool-in-a-swift-program/25880106#25880106
