### PR TITLE
Switched source for device model information on iOS

### DIFF
--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -39,7 +39,7 @@ public class Analytics {
      In the case of a dead instance, an assert will be thrown when in DEBUG builds to
      assist developers in knowning that `shared()` is being called too soon.
      */
-    static func shared() -> Analytics {
+    public static func shared() -> Analytics {
         if let a = firstInstance {
             if a.isDead == false {
                 return a

--- a/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
@@ -80,13 +80,14 @@ internal class iOSVendorSystem: VendorSystem {
     }
     
     private func deviceModel() -> String {
-        var name: [Int32] = [CTL_HW, HW_MACHINE]
-        var size: Int = 2
-        sysctl(&name, 2, nil, &size, nil, 0)
-        var hw_machine = [CChar](repeating: 0, count: Int(size))
-        sysctl(&name, 2, &hw_machine, &size, nil, 0)
-        let model = String(cString: hw_machine)
-        return model
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+        return identifier
     }
 }
 


### PR DESCRIPTION
- Use the same mechanism as macOS.
- Fixes #349 