### PR TITLE
Add network path monitoring / backoff.

### DIFF
--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -30,6 +30,8 @@ public class Analytics {
     static internal weak var firstInstance: Analytics? = nil
 
     @Atomic static internal var activeWriteKeys = [String]()
+    
+    internal var settingsRefreshTimer: QueueTimer? = nil
 
     /**
      This method isn't a traditional singleton implementation.  It's provided here

--- a/Sources/Segment/Configuration.swift
+++ b/Sources/Segment/Configuration.swift
@@ -68,6 +68,7 @@ public class Configuration {
         var storageMode: StorageMode = .disk
         var anonymousIdGenerator: AnonymousIdGenerator = SegmentAnonymousId()
         var httpSession: (() -> any HTTPSession) = HTTPSessions.urlSession
+        var monitorNetworkPath: NetworkPathMonitor = .none
     }
 
     internal var values: Values
@@ -281,6 +282,14 @@ public extension Configuration {
     @discardableResult
     func httpSession(_ httpSession: @escaping @autoclosure () -> any HTTPSession) -> Configuration {
         values.httpSession = httpSession
+        return self
+    }
+    
+    /// Monitors the network path.  When set to `true`, segment must be reachable for event batches to be uploaded.
+    /// Setting to `false` preserves existing behavior and is the default.
+    @discardableResult
+    func monitorNetworkPath(_ value: NetworkPathMonitor) -> Configuration {
+        values.monitorNetworkPath = value
         return self
     }
 }

--- a/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
@@ -333,7 +333,7 @@ internal class ConnectionMonitor {
     @Atomic var connectionStatus: ConnectionStatus = .unknown
     
     init() {
-        self.timer = QueueTimer(interval: 300, immediate: true) { [weak self] in
+        self.timer = QueueTimer(interval: 300, immediate: true) { [weak self] _ in
             guard let self else { return }
             self.check()
         }

--- a/Sources/Segment/Settings.swift
+++ b/Sources/Segment/Settings.swift
@@ -149,7 +149,11 @@ extension Analytics {
         }
     }
     
-    internal func checkSettings() {
+    /**
+     Stops the analytics timeline and begins to fetch settings from Segment. Upon
+     completion, all plugins will be notified, and the timeline started again.
+     */
+    public func checkSettings() {
         #if DEBUG
         if isUnitTesting {
             // we don't really wanna wait for this network call during tests...

--- a/Sources/Segment/Startup.swift
+++ b/Sources/Segment/Startup.swift
@@ -106,7 +106,7 @@ extension Analytics {
         // now set up a timer to do it every 24 hrs.
         // mac apps change focus a lot more than iOS apps, so this
         // seems more appropriate here.
-        QueueTimer.schedule(interval: .days(1), queue: .main) { [weak self] in
+        settingsRefreshTimer = QueueTimer.schedule(interval: .days(1), queue: .main) { [weak self] _ in
             self?.checkSettings()
         }
     }

--- a/Sources/Segment/Utilities/Networking/HTTPClient.swift
+++ b/Sources/Segment/Utilities/Networking/HTTPClient.swift
@@ -27,9 +27,6 @@ public class HTTPClient {
     private var cdnHost: String
 
     private weak var analytics: Analytics?
-    
-    // say segment is reachable until we know otherwise.
-    @Atomic internal var segmentReachable: Bool = true
 
     init(analytics: Analytics) {
         self.analytics = analytics

--- a/Sources/Segment/Utilities/Networking/HTTPClient.swift
+++ b/Sources/Segment/Utilities/Networking/HTTPClient.swift
@@ -27,6 +27,9 @@ public class HTTPClient {
     private var cdnHost: String
 
     private weak var analytics: Analytics?
+    
+    // say segment is reachable until we know otherwise.
+    @Atomic internal var segmentReachable: Bool = true
 
     init(analytics: Analytics) {
         self.analytics = analytics

--- a/Sources/Segment/Utilities/Networking/HTTPClient.swift
+++ b/Sources/Segment/Utilities/Networking/HTTPClient.swift
@@ -27,6 +27,9 @@ public class HTTPClient {
     private var cdnHost: String
 
     private weak var analytics: Analytics?
+    
+    // say segment is reachable until we know otherwise.
+    @Atomic internal var segmentReachable: Bool = true
 
     init(analytics: Analytics) {
         self.analytics = analytics
@@ -110,6 +113,8 @@ public class HTTPClient {
                 completion(.failure(HTTPClientErrors.statusCode(code: httpResponse.statusCode)))
             case 429:
                 analytics?.reportInternalError(AnalyticsError.networkServerLimited(httpResponse.statusCode))
+                completion(.failure(HTTPClientErrors.statusCode(code: httpResponse.statusCode)))
+            case 540: // used to test offline mode
                 completion(.failure(HTTPClientErrors.statusCode(code: httpResponse.statusCode)))
             default:
                 analytics?.reportInternalError(AnalyticsError.networkServerRejected(httpResponse.statusCode))

--- a/Sources/Segment/Utilities/Policies/IntervalBasedFlushPolicy.swift
+++ b/Sources/Segment/Utilities/Policies/IntervalBasedFlushPolicy.swift
@@ -40,7 +40,7 @@ public class IntervalBasedFlushPolicy: FlushPolicy,
             guard let self = self else { return }
             guard let a = self.analytics else { return }
             guard let system: System = a.store.currentState() else { return }
-            self.flushTimer = QueueTimer(interval: system.configuration.values.flushInterval) { [weak self] in
+            self.flushTimer = QueueTimer(interval: system.configuration.values.flushInterval) { [weak self] _ in
                 self?.analytics?.flush()
             }
         }

--- a/Sources/Segment/Utilities/QueueTimer.swift
+++ b/Sources/Segment/Utilities/QueueTimer.swift
@@ -16,18 +16,17 @@ internal class QueueTimer {
     let interval: TimeInterval
     let timer: DispatchSourceTimer
     let queue: DispatchQueue
-    let handler: () -> Void
+    let handler: (QueueTimer?) -> Void
     
     @Atomic var state: State = .suspended
     
-    static var timers = [QueueTimer]()
-    
-    static func schedule(interval: TimeInterval, immediate: Bool = false, queue: DispatchQueue = .main, handler: @escaping () -> Void) {
+    static func schedule(interval: TimeInterval, immediate: Bool = false, queue: DispatchQueue = .main, handler: @escaping (QueueTimer?) -> Void) -> QueueTimer {
         let timer = QueueTimer(interval: interval, queue: queue, handler: handler)
-        Self.timers.append(timer)
+        //Self.timers.append(timer)
+        return timer
     }
 
-    init(interval: TimeInterval, immediate: Bool = false, queue: DispatchQueue = .main, handler: @escaping () -> Void) {
+    init(interval: TimeInterval, immediate: Bool = false, queue: DispatchQueue = .main, handler: @escaping (QueueTimer?) -> Void) {
         self.interval = interval
         self.queue = queue
         self.handler = handler
@@ -39,7 +38,7 @@ internal class QueueTimer {
             timer.schedule(deadline: .now() + self.interval, repeating: self.interval)
         }
         timer.setEventHandler { [weak self] in
-            self?.handler()
+            self?.handler(self)
         }
         resume()
     }
@@ -51,6 +50,10 @@ internal class QueueTimer {
         // if timer is suspended, we must resume if we're going to cancel.
         timer.cancel()
         resume()
+    }
+    
+    func cancel() {
+        
     }
     
     func suspend() {

--- a/Tests/Segment-Tests/HTTPClient_Tests.swift
+++ b/Tests/Segment-Tests/HTTPClient_Tests.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Sneed on 1/21/21.
 //
 
-#if !os(Linux) && !os(Windows)
+#if !os(Linux) && !os(Windows) && !os(watchOS)
 
 import XCTest
 @testable import Segment


### PR DESCRIPTION
- Added config option for network path monitoring. Disabled by default.
- Added test to simulate offline mode using 504 status code.
- Refactored QueueTimer to not store a static list.

Partially addresses https://www.reddit.com/r/ArcBrowser/comments/1edyhtu/is_there_a_reason_why_arcs_telemetry_accounts_for/

cc @brianmichel 