### PR TITLE
Fixed lack of url in openURL options output; Added test.

### DIFF
--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -386,8 +386,11 @@ extension Analytics {
 
         var jsonProperties: JSON? = nil
         if let json = try? JSON(options) {
-            jsonProperties = json
-            _ = try? jsonProperties?.add(value: url.absoluteString, forKey: "url")
+            do {
+                jsonProperties = try json.add(value: url.absoluteString, forKey: "url")
+            } catch {
+                jsonProperties = json
+            }
         } else {
             if let json = try? JSON(["url": url.absoluteString]) {
                 jsonProperties = json

--- a/Tests/Segment-Tests/Analytics_Tests.swift
+++ b/Tests/Segment-Tests/Analytics_Tests.swift
@@ -275,6 +275,59 @@ final class Analytics_Tests: XCTestCase {
         XCTAssertTrue(token?.count == 32) // it's a uuid w/o the dashes.  36 becomes 32.
     }
 #endif
+    
+    func testOpenURL() {
+        let analytics = Analytics(configuration: Configuration(writeKey: "test"))
+        let outputReader = OutputReaderPlugin()
+        analytics.add(plugin: outputReader)
+
+        waitUntilStarted(analytics: analytics)
+        
+        let url = URL(string: "https://blah.com")!
+        
+        // you ain't got no options Lt. Dan!
+        analytics.openURL(url)
+        let urlEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
+        XCTAssertEqual(urlEvent?.properties?.dictionaryValue!["url"] as! String, "https://blah.com")
+        
+        // Anyway, like I was sayin' ...
+        let options = [
+            "Shrimp": [
+                "Description": "Fruit of the sea",
+                "CookingMethods": [
+                    "barbecue",
+                    "boil",
+                    "broil",
+                    "bake",
+                    "saute",
+                    "fried (implied)"
+                ],
+                "Types": [
+                    "shrimp kabobs",
+                    "shrimp gumbo",
+                    "pan fried",
+                    "deep fried",
+                    "stir fried",
+                    "pineapple shrimp",
+                    "lemon shrimp",
+                    "coconut shrimp",
+                    "pepper shrimp",
+                    "shrimp soup",
+                    "shrimp stew",
+                    "shrimp salad",
+                    "shrimp and potatoes",
+                    "shrimp burger",
+                    "shrimp sandwich",
+                    "That- that's about it"
+                ]
+            ]
+        ]
+        
+        analytics.openURL(url, options: options)
+        let urlOptionEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
+        XCTAssertEqual(urlOptionEvent?.properties?.dictionaryValue!["url"] as! String, "https://blah.com")
+        XCTAssertNotNil(urlOptionEvent?.properties?.dictionaryValue!["Shrimp"])
+    }
 
     func testTrack() {
         let analytics = Analytics(configuration: Configuration(writeKey: "test"))


### PR DESCRIPTION
- Fixed adding of `url` to the even properties for a deep link.
- Added a test for openURL() to verify changes and code paths.