### PR TITLE
Fix Application Installed event triggered at every app launch

### DIFF
--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
@@ -40,19 +40,19 @@ class iOSLifecycleEvents: PlatformPlugin, iOSLifecycle {
         let currentVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
         let currentBuild: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
 
-        if let previousBuild,
+        if previousBuild == nil {
+            analytics?.track(name: "Application Installed", properties: [
+                "version": currentVersion,
+                "build": currentBuild
+            ])
+        } else if let previousBuild,
            currentBuild != previousBuild {
             analytics?.track(name: "Application Updated", properties: [
                 "previous_version": previousVersion ?? "",
                 "previous_build": previousBuild,
                 "version": currentVersion,
                 "build": currentBuild
-            ])
-        } else {
-            analytics?.track(name: "Application Installed", properties: [
-                "version": currentVersion,
-                "build": currentBuild
-            ])
+            ])            
         }
 
         let sourceApp: String = launchOptions?[UIApplication.LaunchOptionsKey.sourceApplication] as? String ?? ""


### PR DESCRIPTION
Fixes a bug introduced with [this change](https://github.com/segmentio/analytics-swift/commit/eded4ac317ee96feda5bbee75fa5cd996f17798b)

The Application Installed event is trigger on every non-update app launch.

<img width="905" alt="Screenshot 2024-09-10 at 18 21 12" src="https://github.com/user-attachments/assets/32884da9-d9ec-415d-bbb6-b9f12fcaabbe">

Also matching what's [objc sdk is doing](https://github.com/segmentio/analytics-ios/blob/83ad56f3133d1a1e6b2eb7f397764023ad8b2812/Segment/Classes/SEGAnalytics.m#L182)