### PR TITLE
No longer prompt user for local network access on app launch on macOS Sequoia

### DIFF
--- a/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
+++ b/Sources/Segment/Plugins/Platforms/Vendors/AppleUtils.swift
@@ -201,10 +201,6 @@ internal class MacOSVendorSystem: VendorSystem {
         return deviceModel()
     }
     
-    override var name: String {
-        return device.hostName
-    }
-    
     override var identifierForVendor: String? {
         // apple suggested to use this for receipt validation
         // in MAS, works for this too.


### PR DESCRIPTION
Calling `ProcessInfo.processInfo.hostName` causes a new TCC prompt on macOS Sequoia for the user requesting the app be granted local network access. This code path is hit pretty often, typically during app launch. However, nothing in this framework inherently requires local network access, thus by changing the property to `ProcessInfo.processInfo.userName` instead, any app linking this framework will no longer be forced to prompt for local network access. 