### PR TITLE
feat: add AnalyticsError type for setting fetch failed.

### DIFF
--- a/Sources/Segment/Errors.swift
+++ b/Sources/Segment/Errors.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum AnalyticsError: Error {
+public indirect enum AnalyticsError: Error {
     case storageUnableToCreate(String)
     case storageUnableToWrite(String)
     case storageUnableToRename(String)
@@ -16,10 +16,10 @@ public enum AnalyticsError: Error {
     case storageInvalid(String)
     case storageUnknown(Error)
 
-    case networkUnexpectedHTTPCode(Int)
-    case networkServerLimited(Int)
-    case networkServerRejected(Int)
-    case networkUnknown(Error)
+    case networkUnexpectedHTTPCode(URL?, Int)
+    case networkServerLimited(URL?, Int)
+    case networkServerRejected(URL?, Int)
+    case networkUnknown(URL?, Error)
     case networkInvalidData
 
     case jsonUnableToSerialize(Error)
@@ -27,10 +27,11 @@ public enum AnalyticsError: Error {
     case jsonUnknown(Error)
 
     case pluginError(Error)
-    
+
     case enrichmentError(String)
 
-    case settingsFetchError(Error)
+    case settingsFail(AnalyticsError)
+    case batchUploadFail(AnalyticsError)
 }
 
 extension Analytics {

--- a/Sources/Segment/Errors.swift
+++ b/Sources/Segment/Errors.swift
@@ -29,6 +29,8 @@ public enum AnalyticsError: Error {
     case pluginError(Error)
     
     case enrichmentError(String)
+
+    case settingsFetchError(Error)
 }
 
 extension Analytics {

--- a/Sources/Segment/Utilities/Networking/HTTPClient.swift
+++ b/Sources/Segment/Utilities/Networking/HTTPClient.swift
@@ -63,7 +63,7 @@ public class HTTPClient {
 
         let dataTask = session.uploadTask(with: urlRequest, fromFile: batch) { [weak self] (data, response, error) in
             guard let self else { return }
-            handleResponse(data: data, response: response, error: error, completion: completion)
+            handleResponse(data: data, response: response, error: error, urlRequest: urlRequest, completion: completion)
         }
 
         dataTask.resume()
@@ -88,17 +88,17 @@ public class HTTPClient {
 
         let dataTask = session.uploadTask(with: urlRequest, from: data) { [weak self] (data, response, error) in
             guard let self else { return }
-            handleResponse(data: data, response: response, error: error, completion: completion)
+            handleResponse(data: data, response: response, error: error, urlRequest: urlRequest, completion: completion)
         }
         
         dataTask.resume()
         return dataTask
     }
     
-    private func handleResponse(data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Bool, Error>) -> Void) {
+    private func handleResponse(data: Data?, response: URLResponse?, error: Error?, urlRequest: URLRequest, completion: @escaping (_ result: Result<Bool, Error>) -> Void) {
         if let error = error {
             analytics?.log(message: "Error uploading request \(error.localizedDescription).")
-            analytics?.reportInternalError(AnalyticsError.networkUnknown(error))
+            analytics?.reportInternalError(AnalyticsError.networkUnknown(urlRequest.url, error))
             completion(.failure(HTTPClientErrors.unknown(error: error)))
         } else if let httpResponse = response as? HTTPURLResponse {
             switch (httpResponse.statusCode) {
@@ -106,13 +106,13 @@ public class HTTPClient {
                 completion(.success(true))
                 return
             case 300..<400:
-                analytics?.reportInternalError(AnalyticsError.networkUnexpectedHTTPCode(httpResponse.statusCode))
+                analytics?.reportInternalError(AnalyticsError.networkUnexpectedHTTPCode(urlRequest.url, httpResponse.statusCode))
                 completion(.failure(HTTPClientErrors.statusCode(code: httpResponse.statusCode)))
             case 429:
-                analytics?.reportInternalError(AnalyticsError.networkServerLimited(httpResponse.statusCode))
+                analytics?.reportInternalError(AnalyticsError.networkServerLimited(urlRequest.url, httpResponse.statusCode))
                 completion(.failure(HTTPClientErrors.statusCode(code: httpResponse.statusCode)))
             default:
-                analytics?.reportInternalError(AnalyticsError.networkServerRejected(httpResponse.statusCode))
+                analytics?.reportInternalError(AnalyticsError.networkServerRejected(urlRequest.url, httpResponse.statusCode))
                 completion(.failure(HTTPClientErrors.statusCode(code: httpResponse.statusCode)))
             }
         }
@@ -128,21 +128,21 @@ public class HTTPClient {
 
         let dataTask = session.dataTask(with: urlRequest) { [weak self] (data, response, error) in
             if let error = error {
-                self?.analytics?.reportInternalError(AnalyticsError.settingsFetchError(AnalyticsError.networkUnknown(error)))
+                self?.analytics?.reportInternalError(AnalyticsError.settingsFail(AnalyticsError.networkUnknown(settingsURL, error)))
                 completion(false, nil)
                 return
             }
 
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode > 300 {
-                    self?.analytics?.reportInternalError(AnalyticsError.settingsFetchError(AnalyticsError.networkUnexpectedHTTPCode(httpResponse.statusCode)))
+                    self?.analytics?.reportInternalError(AnalyticsError.settingsFail(AnalyticsError.networkUnexpectedHTTPCode(settingsURL, httpResponse.statusCode)))
                     completion(false, nil)
                     return
                 }
             }
 
             guard let data = data else {
-                self?.analytics?.reportInternalError(AnalyticsError.settingsFetchError(AnalyticsError.networkInvalidData))
+                self?.analytics?.reportInternalError(AnalyticsError.settingsFail(AnalyticsError.networkInvalidData))
                 completion(false, nil)
                 return
             }
@@ -151,7 +151,7 @@ public class HTTPClient {
                 let responseJSON = try JSONDecoder.default.decode(Settings.self, from: data)
                 completion(true, responseJSON)
             } catch {
-                self?.analytics?.reportInternalError(AnalyticsError.settingsFetchError(AnalyticsError.jsonUnableToDeserialize(error)))
+                self?.analytics?.reportInternalError(AnalyticsError.settingsFail(AnalyticsError.jsonUnableToDeserialize(error)))
                 completion(false, nil)
                 return
             }

--- a/Sources/Segment/Utilities/Networking/HTTPClient.swift
+++ b/Sources/Segment/Utilities/Networking/HTTPClient.swift
@@ -128,21 +128,21 @@ public class HTTPClient {
 
         let dataTask = session.dataTask(with: urlRequest) { [weak self] (data, response, error) in
             if let error = error {
-                self?.analytics?.reportInternalError(AnalyticsError.networkUnknown(error))
+                self?.analytics?.reportInternalError(AnalyticsError.settingsFetchError(AnalyticsError.networkUnknown(error)))
                 completion(false, nil)
                 return
             }
 
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode > 300 {
-                    self?.analytics?.reportInternalError(AnalyticsError.networkUnexpectedHTTPCode(httpResponse.statusCode))
+                    self?.analytics?.reportInternalError(AnalyticsError.settingsFetchError(AnalyticsError.networkUnexpectedHTTPCode(httpResponse.statusCode)))
                     completion(false, nil)
                     return
                 }
             }
 
             guard let data = data else {
-                self?.analytics?.reportInternalError(AnalyticsError.networkInvalidData)
+                self?.analytics?.reportInternalError(AnalyticsError.settingsFetchError(AnalyticsError.networkInvalidData))
                 completion(false, nil)
                 return
             }
@@ -151,7 +151,7 @@ public class HTTPClient {
                 let responseJSON = try JSONDecoder.default.decode(Settings.self, from: data)
                 completion(true, responseJSON)
             } catch {
-                self?.analytics?.reportInternalError(AnalyticsError.jsonUnableToDeserialize(error))
+                self?.analytics?.reportInternalError(AnalyticsError.settingsFetchError(AnalyticsError.jsonUnableToDeserialize(error)))
                 completion(false, nil)
                 return
             }


### PR DESCRIPTION
Adding AnalyticsError.settingsFetchFailed(Error) type.

Wrap all the errors that occur while fetching settings using the new type.