### PR TITLE
feat: Allow for more granular tracked lifecycle events to track

### DIFF
--- a/Examples/apps/BasicExample/BasicExample/AppDelegate.swift
+++ b/Examples/apps/BasicExample/BasicExample/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         
         let configuration = Configuration(writeKey: "WRITE KEY")
-            .trackApplicationLifecycleEvents(true)
+            .setTrackedApplicationLifecycleEvents(.all)
             .flushInterval(10)
             .flushAt(2)
         

--- a/Examples/apps/DestinationsExample/DestinationsExample/AppDelegate.swift
+++ b/Examples/apps/DestinationsExample/DestinationsExample/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         
         let configuration = Configuration(writeKey: "EioRQCqLHUECnoSseEguI8GnxOlZTOyX")
-            .trackApplicationLifecycleEvents(true)
+            .setTrackedApplicationLifecycleEvents(.all)
             .flushInterval(1)
         
         analytics = Analytics(configuration: configuration)

--- a/Examples/apps/MacExample/MacExample/AppDelegate.swift
+++ b/Examples/apps/MacExample/MacExample/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Insert code here to initialize your application
         
         let configuration = Configuration(writeKey: "<WRITE KEY>")
-            .trackApplicationLifecycleEvents(true)
+            .setTrackedApplicationLifecycleEvents(.all)
             .flushInterval(10)
             .flushAt(1)
             .errorHandler { error in

--- a/Examples/apps/ObjCExample/ObjCExample/AppDelegate.m
+++ b/Examples/apps/ObjCExample/ObjCExample/AppDelegate.m
@@ -21,7 +21,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
     SEGConfiguration *config = [[SEGConfiguration alloc] initWithWriteKey:@"<WRITE KEY>"];
-    config.trackApplicationLifecycleEvents = YES;
+    config.trackApplicationLifecycleEvents = SEGTrackedLifecycleEvent.all;
     config.flushAt = 1;
     
     _analytics = [[SEGAnalytics alloc] initWithConfiguration: config];

--- a/Examples/apps/SegmentExtensionsExample/ArticleWidget/ArticleWidget.swift
+++ b/Examples/apps/SegmentExtensionsExample/ArticleWidget/ArticleWidget.swift
@@ -101,5 +101,5 @@ extension Analytics {
     static var main = Analytics(configuration:
                                     Configuration(writeKey: "ABCD")
                                     .flushAt(3)
-                                    .trackApplicationLifecycleEvents(true))
+                                    .setTrackedApplicationLifecycleEvents(.all))
 }

--- a/Examples/apps/SegmentSwiftUIExample/SegmentSwiftUIExample/SegmentSwiftUIExampleApp.swift
+++ b/Examples/apps/SegmentSwiftUIExample/SegmentSwiftUIExample/SegmentSwiftUIExampleApp.swift
@@ -21,5 +21,5 @@ extension Analytics {
     static var main = Analytics(configuration:
                                     Configuration(writeKey: "ABCD")
                                     .flushAt(3)
-                                    .trackApplicationLifecycleEvents(true))
+                                    .setTrackedApplicationLifecycleEvents(.all))
 }

--- a/Examples/apps/watchOSExample/watchOSExample WatchKit Extension/ExtensionDelegate.swift
+++ b/Examples/apps/watchOSExample/watchOSExample WatchKit Extension/ExtensionDelegate.swift
@@ -14,7 +14,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
     func applicationDidFinishLaunching() {
         // Perform any final initialization of your application.
         let configuration = Configuration(writeKey: "WRITE KEY")
-            .trackApplicationLifecycleEvents(true)
+            .setTrackedApplicationLifecycleEvents(.all)
             .flushInterval(10)
         
         analytics = Analytics(configuration: configuration)

--- a/Examples/tasks/MultiInstance.swift
+++ b/Examples/tasks/MultiInstance.swift
@@ -38,9 +38,9 @@ import Segment
 extension Analytics {
     static var main = Analytics(configuration: Configuration(writeKey: "1234")
                                     .flushAt(3)
-                                    .trackApplicationLifecycleEvents(true))
-    
+                                    .setTrackedApplicationLifecycleEvents(.all))
+
     static var support = Analytics(configuration: Configuration(writeKey: "5678")
                                     .flushAt(10)
-                                    .trackApplicationLifecycleEvents(false))
+                                    .setTrackedApplicationLifecycleEvents(.none))
 }

--- a/Sources/Segment/ObjC/ObjCConfiguration.swift
+++ b/Sources/Segment/ObjC/ObjCConfiguration.swift
@@ -29,12 +29,12 @@ public class ObjCConfiguration: NSObject {
 
     /// Opt-in/out of tracking lifecycle events.  The default value is `false`.
     @objc
-    public var trackApplicationLifecycleEvents: Bool {
+    public var trackApplicationLifecycleEvents: TrackedLifecycleEvent {
         get {
-            return configuration.values.trackApplicationLifecycleEvents
+            return configuration.values.trackedApplicationLifecycleEvents
         }
         set(value) {
-            configuration.trackApplicationLifecycleEvents(value)
+            configuration.setTrackedApplicationLifecycleEvents(value)
         }
     }
 

--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
@@ -25,15 +25,10 @@ class iOSLifecycleEvents: PlatformPlugin, iOSLifecycle {
     private var didFinishLaunching = false
     
     func application(_ application: UIApplication?, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-        
         // Make sure we aren't double calling application:didFinishLaunchingWithOptions
         // by resetting the check at the start
         _didFinishLaunching.set(true)
-        
-        if analytics?.configuration.values.trackApplicationLifecycleEvents == false {
-            return
-        }
-        
+
         let previousVersion: String? = UserDefaults.standard.string(forKey: Self.versionKey)
         let previousBuild: String? = UserDefaults.standard.string(forKey: Self.buildKey)
 
@@ -41,65 +36,66 @@ class iOSLifecycleEvents: PlatformPlugin, iOSLifecycle {
         let currentBuild: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
 
         if previousBuild == nil {
-            analytics?.track(name: "Application Installed", properties: [
-                "version": currentVersion,
-                "build": currentBuild
-            ])
-        } else if let previousBuild,
-           currentBuild != previousBuild {
-            analytics?.track(name: "Application Updated", properties: [
-                "previous_version": previousVersion ?? "",
-                "previous_build": previousBuild,
-                "version": currentVersion,
-                "build": currentBuild
-            ])            
+            if analytics?.configuration.values.trackedApplicationLifecycleEvents.contains(.applicationInstalled) == true {
+                analytics?.track(name: "Application Installed", properties: [
+                    "version": currentVersion,
+                    "build": currentBuild
+                ])
+            }
+        } else if let previousBuild, currentBuild != previousBuild {
+            if analytics?.configuration.values.trackedApplicationLifecycleEvents.contains(.applicationUpdated) == true {
+                analytics?.track(name: "Application Updated", properties: [
+                    "previous_version": previousVersion ?? "",
+                    "previous_build": previousBuild,
+                    "version": currentVersion,
+                    "build": currentBuild
+                ])
+            }
         }
 
-        let sourceApp: String = launchOptions?[UIApplication.LaunchOptionsKey.sourceApplication] as? String ?? ""
-        let url: String = launchOptions?[UIApplication.LaunchOptionsKey.url] as? String ?? ""
-        
-        analytics?.track(name: "Application Opened", properties: [
-            "from_background": false,
-            "version": currentVersion,
-            "build": currentBuild,
-            "referring_application": sourceApp,
-            "url": url
-        ])
-        
+        if analytics?.configuration.values.trackedApplicationLifecycleEvents.contains(.applicationOpened) == true {
+            let sourceApp: String = launchOptions?[UIApplication.LaunchOptionsKey.sourceApplication] as? String ?? ""
+            let url: String = launchOptions?[UIApplication.LaunchOptionsKey.url] as? String ?? ""
+
+            analytics?.track(name: "Application Opened", properties: [
+                "from_background": false,
+                "version": currentVersion,
+                "build": currentBuild,
+                "referring_application": sourceApp,
+                "url": url
+            ])
+        }
+
         UserDefaults.standard.setValue(currentVersion, forKey: Self.versionKey)
         UserDefaults.standard.setValue(currentBuild, forKey: Self.buildKey)
     }
     
     func applicationWillEnterForeground(application: UIApplication?) {
-        if analytics?.configuration.values.trackApplicationLifecycleEvents == false {
-            return
-        }
-        
-        let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-        let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
-        
-        if didFinishLaunching == false {
-            analytics?.track(name: "Application Opened", properties: [
-                "from_background": true,
-                "version": currentVersion ?? "",
-                "build": currentBuild ?? ""
-            ])
+        if analytics?.configuration.values.trackedApplicationLifecycleEvents.contains(.applicationOpened) == true {
+            let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+            let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+
+            if didFinishLaunching == false {
+                analytics?.track(name: "Application Opened", properties: [
+                    "from_background": true,
+                    "version": currentVersion ?? "",
+                    "build": currentBuild ?? ""
+                ])
+            }
         }
     }
     
     func applicationDidEnterBackground(application: UIApplication?) {
         _didFinishLaunching.set(false)
-        if analytics?.configuration.values.trackApplicationLifecycleEvents == false {
-            return
+        if analytics?.configuration.values.trackedApplicationLifecycleEvents.contains(.applicationBackgrounded) == true {
+            analytics?.track(name: "Application Backgrounded")
         }
-        analytics?.track(name: "Application Backgrounded")
     }
     
     func applicationDidBecomeActive(application: UIApplication?) {
-        if analytics?.configuration.values.trackApplicationLifecycleEvents == false {
-            return
+        if analytics?.configuration.values.trackedApplicationLifecycleEvents.contains(.applicationForegrounded) == true {
+            analytics?.track(name: "Application Foregrounded")
         }
-        analytics?.track(name: "Application Foregrounded")
     }
 }
 

--- a/Sources/Segment/Startup.swift
+++ b/Sources/Segment/Startup.swift
@@ -48,7 +48,7 @@ extension Analytics: Subscriber {
         plugins += VendorSystem.current.requiredPlugins
 
         // setup lifecycle if desired
-        if configuration.values.trackApplicationLifecycleEvents, operatingMode != .synchronous {
+        if configuration.values.trackedApplicationLifecycleEvents != .none, operatingMode != .synchronous {
             #if os(iOS) || os(tvOS) || os(visionOS) || os(visionOS)
             plugins.append(iOSLifecycleEvents())
             #endif


### PR DESCRIPTION
Hi Segment team 👋🏻,

We found ourselves not wanting to track all the lifecycle events in our app. As far as I can tell there was no way to filter them so I implemented this as an OptionSet instead of a boolean value.

Let me know if this is acceptable and/or if you have any questions or suggestions.

Thanks.
Kevin