### PR TITLE
fix: call proper flush method when entering background.

### DIFF
--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -108,7 +108,7 @@ public class SegmentDestination: DestinationPlugin, Subscriber, FlushCompletion 
     internal func enterForeground() { }
 
     internal func enterBackground() {
-        flush()
+        analytics?.flush()
     }
 
     // MARK: - Event Parsing Methods


### PR DESCRIPTION
- Refer ticket - https://twilio-engineering.atlassian.net/browse/LIBRARIES-2112
- Removed dead flush method call from `enterBackground()`