### PR TITLE
Wire up UIApplication.willTerminateNotification to iOSLifecycle event

### DIFF
--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
@@ -77,6 +77,8 @@ class iOSLifecycleMonitor: PlatformPlugin {
             self.significantTimeChange(notification: notification)
         case UIApplication.backgroundRefreshStatusDidChangeNotification:
             self.backgroundRefreshDidChange(notification: notification)
+        case UIApplication.willTerminateNotification:
+            self.willTerminate(notification: notification)
         default:
             
             break


### PR DESCRIPTION
iOSLifecycleMonitor defined the notification center `UIApplication.willTerminateNotification` app notification and a handler function but never wired it up. This fix wires it up.