### PR TITLE
fix: extract NSURL from launch options

### DIFF
--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleEvents.swift
@@ -56,7 +56,7 @@ class iOSLifecycleEvents: PlatformPlugin, iOSLifecycle {
         }
 
         let sourceApp: String = launchOptions?[UIApplication.LaunchOptionsKey.sourceApplication] as? String ?? ""
-        let url: String = launchOptions?[UIApplication.LaunchOptionsKey.url] as? String ?? ""
+        let url = urlFrom(launchOptions)
         
         analytics?.track(name: "Application Opened", properties: [
             "from_background": false,
@@ -100,6 +100,16 @@ class iOSLifecycleEvents: PlatformPlugin, iOSLifecycle {
             return
         }
         analytics?.track(name: "Application Foregrounded")
+    }
+    
+    private func urlFrom(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> String {
+        if let url = launchOptions?[UIApplication.LaunchOptionsKey.url] as? String {
+            return url
+        }
+        if let url = launchOptions?[UIApplication.LaunchOptionsKey.url] as? NSURL, let rawUrl =  url.absoluteString  {
+            return rawUrl
+        }
+        return ""
     }
 }
 


### PR DESCRIPTION
## Description
When extracting the url from launch options we always receive empty string. Using the debugger the spec changed to NSURL instead of String.
With this change, two ways are considered, String as it and NSURL 
<img width="525" alt="Screenshot 2025-07-04 at 9 41 55 AM" src="https://github.com/user-attachments/assets/4f68672d-a853-4b79-92c9-07593404c35d" />
