### PR TITLE
Correct time calculations

### DIFF
--- a/Sources/Segment/Utilities/QueueTimer.swift
+++ b/Sources/Segment/Utilities/QueueTimer.swift
@@ -73,7 +73,7 @@ internal class QueueTimer {
 
 extension TimeInterval {
     static func milliseconds(_ value: Int) -> TimeInterval {
-        return TimeInterval(value / 1000)
+        return TimeInterval(value) / 1000
     }
     
     static func seconds(_ value: Int) -> TimeInterval {
@@ -81,10 +81,10 @@ extension TimeInterval {
     }
     
     static func hours(_ value: Int) -> TimeInterval {
-        return TimeInterval(60 * value)
+        return TimeInterval(60 * 60 * value)
     }
     
     static func days(_ value: Int) -> TimeInterval {
-        return TimeInterval((60 * value) * 24)
+        return TimeInterval((60 * 60 * value) * 24)
     }
 }


### PR DESCRIPTION
All but one of the extensions on `TimeInterval` in `QueueTimer.swift` yielded incorrect values.