### PR TITLE
Fix background task registration for iOS uploads

### DIFF
--- a/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
+++ b/Sources/Segment/Plugins/Platforms/iOS/iOSLifecycleMonitor.swift
@@ -188,18 +188,19 @@ extension SegmentDestination: iOSLifecycle {
 }
 
 extension SegmentDestination.UploadTaskInfo {
-    init(url: URL?, data: Data?, task: URLSessionDataTask) {
+    init(url: URL?, data: Data?, task: any DataTask) {
         self.url = url
         self.data = data
         self.task = task
-        
-        if let application = UIApplication.safeShared {
+
+        if let application = UIApplication.safeShared,
+           let urlTask = task as? URLSessionTask {
             var taskIdentifier: UIBackgroundTaskIdentifier = .invalid
             taskIdentifier = application.beginBackgroundTask {
-                task.cancel()
+                urlTask.cancel()
                 application.endBackgroundTask(taskIdentifier)
             }
-            
+
             self.cleanup = {
                 application.endBackgroundTask(taskIdentifier)
             }


### PR DESCRIPTION
## Summary

- Fixed iOS background task registration that was broken after the HTTPSession abstraction change (c4f8f12)
- The issue: Swift's overload resolution picked the memberwise initializer instead of the extension initializer that registers background tasks
- The fix: Changed extension initializer to accept `any DataTask` and cast to `URLSessionTask` internally
- This ensures `beginBackgroundTask()` is properly invoked, preventing uploads from being killed when the app backgrounds

## Test plan

- [x] All 117 existing tests pass
- [x] Project builds successfully
- [ ] Manual testing on iOS device to verify background uploads complete when app backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)