### PR TITLE
Fix: Tolerate non-DestinationPlugin entries in DestinationMetadataPlugin to prevent SDK from not adding Metadata when it's expected

### DIFF
--- a/Sources/Segment/Plugins/DestinationMetadataPlugin.swift
+++ b/Sources/Segment/Plugins/DestinationMetadataPlugin.swift
@@ -21,7 +21,7 @@ public class DestinationMetadataPlugin: Plugin {
         }
         
         guard let integrationSettings = analytics?.settings() else { return event }
-        guard let destinations = analytics?.timeline.plugins[.destination]?.plugins as? [DestinationPlugin] else { return event }
+        guard let destinations = analytics?.timeline.plugins[.destination]?.plugins.compactMap({ $0 as? DestinationPlugin }), !destinations.isEmpty else { return event }
         
         // Mark all loaded and enabled destinations as bundled
         var bundled: Set<String> = []


### PR DESCRIPTION
## Summary

- `DestinationMetadataPlugin.execute` cast the entire destination plugins array with `as? [DestinationPlugin]`. If any plugin in the `.destination` mediator does not conform to `DestinationPlugin` (but has `.destination` type), the cast fails and metadata enrichment is silently skipped for all events.
- Replaced with `compactMap` so non-conforming plugins are individually filtered out instead of failing the whole operation.

We internally faced that in our company, which resulted in Segment treating all events sent in Device mode, meaning none of the events were forwarded to other destinations
   - In our case the fix was "simple", we changed plugin type to "DestinationPlugin" 
   - Merging this change to the SDK itself may help other teams in the future and reduce number of support tickets at Segment, as technically any plugin can return `.destination` type.

## Test plan

- [x] Added `testDestinationMetadataWithNonDestinationPluginType` — verifies metadata is correctly populated when a non-`DestinationPlugin` with `.destination` type is present
- [x] Existing `testDestinationMetadata` and `testDestinationMetadataUnbundled` still pass