### PR TITLE
Align e2e-cli types with sdk-e2e-tests

### DIFF
--- a/e2e-cli/Sources/E2ECLI/main.swift
+++ b/e2e-cli/Sources/E2ECLI/main.swift
@@ -102,12 +102,18 @@ func sendEvent(analytics: Analytics, event: [String: AnyCodable]) throws {
     }
 
     let userId = event["userId"]?.stringValue ?? ""
+    let anonymousId = event["anonymousId"]?.stringValue
+    let messageId = event["messageId"]?.stringValue
+    let timestamp = event["timestamp"]?.stringValue
     let traits = event["traits"]?.dictValue ?? [:]
     let properties = event["properties"]?.dictValue ?? [:]
     let eventName = event["event"]?.stringValue
     let name = event["name"]?.stringValue
+    let category = event["category"]?.stringValue
     let groupId = event["groupId"]?.stringValue
     let previousId = event["previousId"]?.stringValue
+    let context = event["context"]?.dictValue
+    let integrations = event["integrations"]?.dictValue
 
     switch type {
     case "identify":


### PR DESCRIPTION
## Summary
- Add missing field extraction in e2e-cli: `anonymousId`, `messageId`, `timestamp`, `category`, `context`, `integrations`
- Fields are parsed from input JSON for type consistency; the Swift SDK API doesn't accept these as direct parameters
- Aligns the CLI's type handling with the canonical types defined in `sdk-e2e-tests/src/cli/types.ts`

## Test plan
- [ ] Verify `cd e2e-cli && swift build` builds cleanly
- [ ] Run e2e tests with `./e2e-cli/run-e2e.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)