### PR TITLE
Add settings e2e test suite, update CI workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,10 +14,17 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      e2e_tests_ref:
+        description: 'Branch or ref of sdk-e2e-tests to use'
+        required: false
+        default: 'main'
 
 jobs:
   e2e-tests:
+    # Skip on fork PRs where repo secrets aren't available
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: macos-latest
 
     steps:
@@ -30,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: segmentio/sdk-e2e-tests
+          ref: ${{ inputs.e2e_tests_ref || 'main' }}
           token: ${{ secrets.E2E_TESTS_TOKEN }}
           path: sdk-e2e-tests
 

--- a/e2e-cli/e2e-config.json
+++ b/e2e-cli/e2e-config.json
@@ -1,6 +1,6 @@
 {
   "sdk": "swift",
-  "test_suites": "basic",
+  "test_suites": "basic,settings",
   "auto_settings": true,
   "patch": "analytics-swift-http.patch",
   "env": {}


### PR DESCRIPTION
- Add `settings` to e2e test_suites, enable `auto_settings`
- Skip e2e tests on fork PRs (secrets unavailable)
- Accept `e2e_tests_ref` workflow input for cross-repo test validation