### PR TITLE
feat: CDN httpConfig support for retry-settings tests

### DIFF
--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -66,31 +66,34 @@ public class SegmentDestination: DestinationPlugin, Subscriber, FlushCompletion 
     public func update(settings: Settings, type: UpdateType) {
         guard let analytics = analytics else { return }
         let segmentInfo = settings.integrationSettings(forKey: self.key)
-        // if customer cycles out a writekey at app.segment.com, this is necessary.
-        /*
-         This actually works differently than anticipated.  It was thought that when a writeKey was
-         revoked, it's old writekey would redirect to the new, but it doesn't work this way.  As a result
-         it doesn't appear writekey can be changed remotely.  Leaving this here in case that changes in the
-         near future (written on 10/29/2022).
-         */
-        /*
-        if let key = segmentInfo?[Self.Constants.apiKey.rawValue] as? String, key.isEmpty == false {
-            if key != analytics.configuration.values.writeKey {
-                /*
-                 - would need to flush.
-                 - would need to change the writeKey across the system.
-                 - would need to re-init storage.
-                 - probably other things too ...
-                 */
-            }
-        }
-         */
+        var needsHTTPClientRebuild = false
+
         // if customer specifies a different apiHost (ie: eu1.segmentapis.com) at app.segment.com ...
         if let host = segmentInfo?[Self.Constants.apiHost.rawValue] as? String, host.isEmpty == false {
             if host != analytics.configuration.values.apiHost {
                 analytics.configuration.values.apiHost = host
-                httpClient = HTTPClient(analytics: analytics)
+                needsHTTPClientRebuild = true
             }
+        }
+
+        // Read httpConfig from CDN settings at integrations["Segment.io"].httpConfig
+        if let httpConfigDict = segmentInfo?["httpConfig"] as? [String: Any],
+           let data = try? JSONSerialization.data(withJSONObject: httpConfigDict),
+           var cdnConfig = try? JSONDecoder.default.decode(HttpConfig.self, from: data) {
+            // CDN-sourced config defaults enabled to true (presence of httpConfig implies active).
+            // Only honor explicit `enabled: false` from CDN.
+            let rlDict = httpConfigDict["rateLimitConfig"] as? [String: Any]
+            cdnConfig.rateLimitConfig.enabled = (rlDict?["enabled"] as? Bool) ?? true
+
+            let boDict = httpConfigDict["backoffConfig"] as? [String: Any]
+            cdnConfig.backoffConfig.enabled = (boDict?["enabled"] as? Bool) ?? true
+
+            analytics.configuration.values.httpConfig = cdnConfig
+            needsHTTPClientRebuild = true
+        }
+
+        if needsHTTPClientRebuild {
+            httpClient = HTTPClient(analytics: analytics)
         }
     }
 

--- a/Sources/Segment/Utilities/Retry/HttpConfig.swift
+++ b/Sources/Segment/Utilities/Retry/HttpConfig.swift
@@ -15,6 +15,13 @@ public struct RateLimitConfig: Codable {
         self.maxRetryInterval = maxRetryInterval
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        self.maxRetryCount = try container.decodeIfPresent(Int.self, forKey: .maxRetryCount) ?? 100
+        self.maxRetryInterval = try container.decodeIfPresent(Int.self, forKey: .maxRetryInterval) ?? 300
+    }
+
     public func validated() -> RateLimitConfig {
         return RateLimitConfig(
             enabled: enabled,
@@ -35,6 +42,13 @@ public struct BackoffConfig: Codable {
     public var default5xxBehavior: RetryBehavior
     public var unknownCodeBehavior: RetryBehavior
     public var statusCodeOverrides: [Int: RetryBehavior]
+
+    enum CodingKeys: String, CodingKey {
+        case enabled, maxRetryCount, baseBackoffInterval, maxBackoffInterval
+        case maxTotalBackoffDuration, jitterPercent
+        case default4xxBehavior, default5xxBehavior, unknownCodeBehavior
+        case statusCodeOverrides
+    }
 
     public init(
         enabled: Bool = false,
@@ -67,6 +81,51 @@ public struct BackoffConfig: Codable {
         self.statusCodeOverrides = statusCodeOverrides
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        self.maxRetryCount = try container.decodeIfPresent(Int.self, forKey: .maxRetryCount) ?? 100
+        self.baseBackoffInterval = try container.decodeIfPresent(Double.self, forKey: .baseBackoffInterval) ?? 0.5
+        self.maxBackoffInterval = try container.decodeIfPresent(Int.self, forKey: .maxBackoffInterval) ?? 300
+        self.maxTotalBackoffDuration = try container.decodeIfPresent(Int.self, forKey: .maxTotalBackoffDuration) ?? 43200
+        self.jitterPercent = try container.decodeIfPresent(Int.self, forKey: .jitterPercent) ?? 10
+        self.default4xxBehavior = try container.decodeIfPresent(RetryBehavior.self, forKey: .default4xxBehavior) ?? .drop
+        self.default5xxBehavior = try container.decodeIfPresent(RetryBehavior.self, forKey: .default5xxBehavior) ?? .retry
+        self.unknownCodeBehavior = try container.decodeIfPresent(RetryBehavior.self, forKey: .unknownCodeBehavior) ?? .drop
+
+        // statusCodeOverrides comes from JSON with string keys like "400": "retry"
+        let defaultOverrides: [Int: RetryBehavior] = [
+            408: .retry, 410: .retry, 429: .retry, 460: .retry,
+            501: .drop, 505: .drop
+        ]
+        if let stringKeyed = try container.decodeIfPresent([String: RetryBehavior].self, forKey: .statusCodeOverrides) {
+            var result = [Int: RetryBehavior]()
+            for (key, value) in stringKeyed {
+                if let code = Int(key) {
+                    result[code] = value
+                }
+            }
+            self.statusCodeOverrides = result
+        } else {
+            self.statusCodeOverrides = defaultOverrides
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(enabled, forKey: .enabled)
+        try container.encode(maxRetryCount, forKey: .maxRetryCount)
+        try container.encode(baseBackoffInterval, forKey: .baseBackoffInterval)
+        try container.encode(maxBackoffInterval, forKey: .maxBackoffInterval)
+        try container.encode(maxTotalBackoffDuration, forKey: .maxTotalBackoffDuration)
+        try container.encode(jitterPercent, forKey: .jitterPercent)
+        try container.encode(default4xxBehavior, forKey: .default4xxBehavior)
+        try container.encode(default5xxBehavior, forKey: .default5xxBehavior)
+        try container.encode(unknownCodeBehavior, forKey: .unknownCodeBehavior)
+        let stringKeyed = Dictionary(uniqueKeysWithValues: statusCodeOverrides.map { (String($0.key), $0.value) })
+        try container.encode(stringKeyed, forKey: .statusCodeOverrides)
+    }
+
     public func validated() -> BackoffConfig {
         let validOverrides = statusCodeOverrides.filter { (code, _) in
             code >= 100 && code <= 599
@@ -97,5 +156,13 @@ public struct HttpConfig: Codable {
     ) {
         self.rateLimitConfig = rateLimitConfig.validated()
         self.backoffConfig = backoffConfig.validated()
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rl = try container.decodeIfPresent(RateLimitConfig.self, forKey: .rateLimitConfig) ?? RateLimitConfig()
+        let bo = try container.decodeIfPresent(BackoffConfig.self, forKey: .backoffConfig) ?? BackoffConfig()
+        self.rateLimitConfig = rl
+        self.backoffConfig = bo
     }
 }

--- a/Sources/Segment/Utilities/Retry/RetryStateMachine.swift
+++ b/Sources/Segment/Utilities/Retry/RetryStateMachine.swift
@@ -25,19 +25,25 @@ public class RetryStateMachine {
         }
 
         // 429 rate limiting
-        if response.statusCode == 429 && config.rateLimitConfig.enabled {
-            let currentTime = response.currentTime
-            return handleRateLimitResponse(state: state, response: response, currentTime: currentTime)
+        if response.statusCode == 429 {
+            if config.rateLimitConfig.enabled {
+                let currentTime = response.currentTime
+                return handleRateLimitResponse(state: state, response: response, currentTime: currentTime)
+            }
+            // Rate limit handling disabled: drop the batch (don't fall through to backoff)
+            var newState = state
+            newState.batchMetadata.removeValue(forKey: response.batchFile)
+            return newState
         }
 
-        // 5xx exponential backoff
+        // Exponential backoff for retryable errors
         let behavior = resolveStatusCodeBehavior(code: response.statusCode)
         if behavior == .retry && config.backoffConfig.enabled {
             let currentTime = response.currentTime
             return handleRetryableError(state: state, response: response, currentTime: currentTime)
         }
 
-        // Drop non-retryable errors (4xx, etc.)
+        // Drop non-retryable errors, or retryable errors when backoff is disabled
         var newState = state
         newState.batchMetadata.removeValue(forKey: response.batchFile)
         return newState
@@ -68,7 +74,16 @@ public class RetryStateMachine {
             clearedState.waitUntilTime = nil
         }
 
-        // Check 2: Per-batch metadata
+        // Check 2: Global rate limit retry count
+        if config.rateLimitConfig.enabled &&
+           clearedState.globalRetryCount >= config.rateLimitConfig.maxRetryCount {
+            var dropState = clearedState
+            dropState.globalRetryCount = 0
+            dropState.batchMetadata.removeValue(forKey: batchFile)
+            return (.dropBatch(reason: .maxRetriesExceeded), dropState)
+        }
+
+        // Check 3: Per-batch metadata
         guard let metadata = clearedState.batchMetadata[batchFile] else {
             return (.proceed, clearedState)
         }
@@ -105,7 +120,14 @@ public class RetryStateMachine {
     /// Returns true if the given status code should result in the batch being dropped (not retried).
     public func shouldDropBatch(statusCode: Int) -> Bool {
         if isLegacyMode { return false }
+
+        // 429 with rate limit handling disabled: drop
+        if statusCode == 429 && !config.rateLimitConfig.enabled { return true }
+
         let behavior = resolveStatusCodeBehavior(code: statusCode)
+        // Retryable error with backoff disabled: drop
+        if behavior == .retry && !config.backoffConfig.enabled { return true }
+
         return behavior == .drop
     }
 

--- a/e2e-cli/e2e-config.json
+++ b/e2e-cli/e2e-config.json
@@ -1,7 +1,9 @@
 {
   "sdk": "swift",
-  "test_suites": "basic,retry,settings",
+  "test_suites": "basic,retry,settings,retry-settings",
   "auto_settings": true,
   "patch": "analytics-swift-http.patch",
-  "env": {}
+  "env": {
+    "HTTP_CONFIG_SETTINGS": "true"
+  }
 }


### PR DESCRIPTION
## Summary
- Add custom `Codable` decoders to `HttpConfig`/`BackoffConfig`/`RateLimitConfig` to handle partial JSON from CDN settings (the default synthesized decoder requires all fields present)
- Decode `statusCodeOverrides` from string-keyed JSON (`"400": "retry"`) to `[Int: RetryBehavior]`
- Read `httpConfig` from `integrations["Segment.io"]` in `SegmentDestination.update()` and rebuild `HTTPClient` when CDN config arrives
- Default `enabled` to `true` for CDN-sourced configs (presence of httpConfig implies active)
- Enforce `rateLimitConfig.maxRetryCount` via `globalRetryCount` in `RetryStateMachine.shouldUploadBatch()`
- Add `retry-settings` test suite to `e2e-config.json`

## Test plan
- [x] All 20 retry-settings e2e tests pass (backoff-settings, rate-limit-settings, partial-config, settings-enabled-flag)
- [x] All 59 existing e2e tests pass (basic, retry, settings) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)