### PR TITLE
fix(core): guard checkSettings() against concurrent in-flight fetches

### DIFF
--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -30,9 +30,25 @@ public class Analytics {
     @Atomic static internal var activeWriteKeys = [String]()
 
     @Atomic internal var lastSettingsCheck: Date = .distantPast
+    @Atomic internal var isCheckingSettings: Bool = false
 
     internal func recordSettingsCheckTimestamp(_ date: Date = Date()) {
         _lastSettingsCheck.set(date)
+    }
+
+    internal func tryBeginCheckingSettings() -> Bool {
+        var didBegin = false
+        _isCheckingSettings.mutate { flag in
+            if !flag {
+                flag = true
+                didBegin = true
+            }
+        }
+        return didBegin
+    }
+
+    internal func endCheckingSettings() {
+        _isCheckingSettings.set(false)
     }
 
     // Used for WaitingPlugin's, see waiting.swift

--- a/Sources/Segment/Settings.swift
+++ b/Sources/Segment/Settings.swift
@@ -154,19 +154,22 @@ extension Analytics {
     }
 
     internal func checkSettings() {
+        guard tryBeginCheckingSettings() else { return }
         recordSettingsCheckTimestamp()
+
         #if DEBUG
         if isUnitTesting {
             // we don't really wanna wait for this network call during tests...
             // but we should make it work similarly.
             pauseEventProcessing()
-            
+
             operatingMode.run(queue: DispatchQueue.main) {
                 if let state: System = self.store.currentState(), let settings = state.settings {
                     self.store.dispatch(action: System.UpdateSettingsAction(settings: settings))
                     self.update(settings: settings)
                 }
                 self.resumeEventProcessing()
+                self.endCheckingSettings()
             }
 
             return
@@ -179,6 +182,8 @@ extension Analytics {
         // stop things; queue in case our settings have changed.
         pauseEventProcessing()
         httpClient.settingsFor(writeKey: writeKey) { (success, settings) in
+            defer { self.endCheckingSettings() }
+
             if success, let s = settings {
                 // put the new settings in the state store.
                 // this will cause them to be cached.

--- a/Tests/Segment-Tests/CheckSettingsConcurrency_Tests.swift
+++ b/Tests/Segment-Tests/CheckSettingsConcurrency_Tests.swift
@@ -1,0 +1,81 @@
+//
+//  CheckSettingsConcurrency_Tests.swift
+//  Segment-Tests
+//
+
+import XCTest
+@testable import Segment
+
+class CheckSettingsConcurrency_Tests: XCTestCase {
+
+    override func setUpWithError() throws {
+        Telemetry.shared.enable = false
+    }
+
+    func testTryBeginCheckingSettingsReturnsTrueWhenFlagIsClear() {
+        let analytics = Analytics(configuration: Configuration(writeKey: uniqueWriteKey()))
+        waitUntilStarted(analytics: analytics)
+        analytics.endCheckingSettings()
+
+        XCTAssertTrue(analytics.tryBeginCheckingSettings())
+        XCTAssertTrue(analytics.isCheckingSettings)
+    }
+
+    func testTryBeginCheckingSettingsReturnsFalseWhenFlagIsSet() {
+        let analytics = Analytics(configuration: Configuration(writeKey: uniqueWriteKey()))
+        waitUntilStarted(analytics: analytics)
+
+        XCTAssertTrue(analytics.tryBeginCheckingSettings())
+        XCTAssertFalse(analytics.tryBeginCheckingSettings())
+    }
+
+    func testEndCheckingSettingsClearsFlag() {
+        let analytics = Analytics(configuration: Configuration(writeKey: uniqueWriteKey()))
+        waitUntilStarted(analytics: analytics)
+
+        _ = analytics.tryBeginCheckingSettings()
+        XCTAssertTrue(analytics.isCheckingSettings)
+
+        analytics.endCheckingSettings()
+        XCTAssertFalse(analytics.isCheckingSettings)
+    }
+
+    func testCheckSettingsClearsFlagAfterCompletion() {
+        let analytics = Analytics(configuration: Configuration(writeKey: uniqueWriteKey()))
+        waitUntilStarted(analytics: analytics)
+
+        analytics.checkSettings()
+
+        let expectation = XCTestExpectation(description: "flag cleared")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            XCTAssertFalse(analytics.isCheckingSettings)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testConcurrentCheckSettingsCallsOnlyOneProceeds() {
+        let analytics = Analytics(configuration: Configuration(writeKey: uniqueWriteKey()))
+        waitUntilStarted(analytics: analytics)
+        analytics.endCheckingSettings()
+
+        var winners = 0
+        let lock = NSLock()
+        let group = DispatchGroup()
+
+        for _ in 0..<32 {
+            group.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                if analytics.tryBeginCheckingSettings() {
+                    lock.lock()
+                    winners += 1
+                    lock.unlock()
+                }
+                group.leave()
+            }
+        }
+
+        group.wait()
+        XCTAssertEqual(winners, 1)
+    }
+}


### PR DESCRIPTION
## Summary

Adds an atomic compare-and-swap at the entry of `checkSettings()` so two callers on different threads can't both fire `URLSession` completions that walk plugins concurrently. The flag is cleared in every completion path — network success, network failure, and the unit-testing short-circuit.

Stacks with the 10-second debounce in #436. The debounce skips the common-case waste; this CAS catches the paths the debounce can't:

- A fetch that takes longer than the debounce window (slow networks, CDN cold starts) — the next foreground after the window passes would otherwise fire a second fetch on top of the still-in-flight first one.
- Two call sites firing `checkSettings()` at nearly the same instant during `Analytics.init()` startup before any timestamp is recorded.

## Changes

- **`Analytics.swift`**:
  - New `@Atomic internal var isCheckingSettings: Bool = false`.
  - `tryBeginCheckingSettings()` — atomic CAS via `_isCheckingSettings.mutate { ... }`, returns `true` only for the winning thread.
  - `endCheckingSettings()` — clears the flag.
- **`Settings.swift`**:
  - `checkSettings()` first calls `tryBeginCheckingSettings()` and bails if a fetch is already in flight.
  - Each exit path clears the flag: `defer { self.endCheckingSettings() }` in the network completion, and an explicit call inside the test-mode `operatingMode.run` block.
- **`CheckSettingsConcurrency_Tests.swift`** (new):
  - `testTryBeginCheckingSettingsReturnsTrueWhenFlagIsClear`
  - `testTryBeginCheckingSettingsReturnsFalseWhenFlagIsSet`
  - `testEndCheckingSettingsClearsFlag`
  - `testCheckSettingsClearsFlagAfterCompletion` — fires `checkSettings()` and asserts the flag returns to `false` after the test-mode completion runs.
  - `testConcurrentCheckSettingsCallsOnlyOneProceeds` — 32 concurrent threads racing through `tryBeginCheckingSettings()`; exactly one wins.

## Scope

- 22 production lines added across `Analytics.swift` and `Settings.swift`.
- 1 new test file, 5 tests.
- No public API change. New symbols are `internal`.
- No dependency changes.
- No deployment-target changes.

## Test plan

- [x] `swift build` succeeds.
- [x] Full test suite passes (205/205 serially, `swift test`).
- [x] Pre-existing `CheckSettingsDebounce_Tests` (4 tests) still pass — debounce unaffected.
- [x] New CAS gate is exercised in single-threaded and 32-way concurrent scenarios.