### PR TITLE
fix(release): correct Version.swift path case; fix stale CONTRIBUTING examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,12 @@ We follow the [conventional commits specification](https://www.conventionalcommi
 
 - `fix`: bug fixes, e.g. fix crash due to deprecated method.
 - `feat`: new features, e.g. add new method to the module.
-- `refactor`: code refactor, e.g. migrate from class components to hooks.
-- `docs`: changes into documentation, e.g. add usage example for the module..
-- `test`: adding or updating tests, eg add integration tests using detox.
+- `refactor`: code refactor, e.g. extract a helper or restructure a plugin in the Timeline.
+- `docs`: changes into documentation, e.g. add usage example for the module.
+- `test`: adding or updating tests, e.g. add XCTest cases under Tests/Segment-Tests for a new flush policy.
 - `chore`: tooling changes, e.g. change CI config.
 
-Our pre-commit hooks verify that your commit message matches this format when committing.
+Please format your commit messages this way; maintainers may ask you to amend commits that don't follow the convention.
 
 
 ### Sending a pull request

--- a/release.sh
+++ b/release.sh
@@ -73,7 +73,7 @@ then
 	exit 1
 fi
 
-versionFile="./sources/${PRODUCT_NAME}/Version.swift"
+versionFile="./Sources/${PRODUCT_NAME}/Version.swift"
 
 # get last line in version.swift
 versionLine=$(tail -n 1 $versionFile)


### PR DESCRIPTION
## Summary

One real (latent) release bug plus two stale-doc fixes. Verified against `main` before editing.

### `release.sh` — version-file path case (the substantive fix)
`versionFile` was set to `./sources/${PRODUCT_NAME}/Version.swift` (lowercase `sources`), but the tracked path is `./Sources/Segment/Version.swift` (capital `S`). On macOS's default case-insensitive filesystem this happens to work, so it has gone unnoticed — but on a **case-sensitive** volume (some CI runners, case-sensitive APFS, Linux) `tail`/`sed` would fail to find the file and the release's version bump + tag step would break. Corrected to `./Sources/`.

### `CONTRIBUTING.md`
- **Commit examples:** the `refactor` and `test` examples ("migrate from class components to hooks", "add integration tests using detox") are React-Native-template leftovers — neither React hooks nor Detox exist in this Swift package. Replaced with Swift/XCTest-relevant examples.
- **Pre-commit claim:** "Our pre-commit hooks verify that your commit message matches this format" is false — there is no commit-msg / pre-commit hook tooling in the repo (no husky, commitlint, lefthook, `.pre-commit-config.yaml`, or `core.hooksPath`). Softened to a non-enforcing note so contributors aren't misled.

## Note
`RELEASING.md` itself was reviewed and is **accurate** — it correctly points to `./release.sh` and matches the script's behavior; no changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
