### PR TITLE
feat: honor Retry-After header on any retryable HTTP response

### DIFF
--- a/Sources/Segment/Utilities/Networking/HTTPClient.swift
+++ b/Sources/Segment/Utilities/Networking/HTTPClient.swift
@@ -166,7 +166,19 @@ public class HTTPClient {
                     batchFile: batchFile,
                     currentTime: timeProvider.now()
                 )
-                retryState = stateMachine.handleResponse(state: retryState, response: responseInfo)
+                let newState = stateMachine.handleResponse(state: retryState, response: responseInfo)
+
+                // Log when Retry-After triggers a new pipeline pause on a non-429 code
+                if let retryAfterSeconds = responseInfo.retryAfterSeconds,
+                   newState.pipelineState == .rateLimited,
+                   retryState.pipelineState != .rateLimited,
+                   httpResponse.statusCode != 429 {
+                    let waitUntil = newState.waitUntilTime.map { Date(timeIntervalSince1970: $0).description } ?? "unknown"
+                    Analytics.segmentLog(message: "Retry-After (\(retryAfterSeconds)s) received on HTTP \(httpResponse.statusCode) — pausing pipeline until \(waitUntil)", kind: .warning)
+                    analytics?.reportInternalError(AnalyticsError.networkServerLimited(url, httpResponse.statusCode))
+                }
+
+                retryState = newState
                 analytics?.storage.saveRetryState(retryState)
             }
 

--- a/Sources/Segment/Utilities/Networking/HTTPClient.swift
+++ b/Sources/Segment/Utilities/Networking/HTTPClient.swift
@@ -168,11 +168,10 @@ public class HTTPClient {
                 )
                 let newState = stateMachine.handleResponse(state: retryState, response: responseInfo)
 
-                // Log when Retry-After triggers a new pipeline pause on a non-429 code
+                // Log when Retry-After triggers a new pipeline pause
                 if let retryAfterSeconds = responseInfo.retryAfterSeconds,
                    newState.pipelineState == .rateLimited,
-                   retryState.pipelineState != .rateLimited,
-                   httpResponse.statusCode != 429 {
+                   retryState.pipelineState != .rateLimited {
                     let waitUntil = newState.waitUntilTime.map { Date(timeIntervalSince1970: $0).description } ?? "unknown"
                     Analytics.segmentLog(message: "Retry-After (\(retryAfterSeconds)s) received on HTTP \(httpResponse.statusCode) — pausing pipeline until \(waitUntil)", kind: .warning)
                     analytics?.reportInternalError(AnalyticsError.networkServerLimited(url, httpResponse.statusCode))

--- a/Sources/Segment/Utilities/Retry/RetryStateMachine.swift
+++ b/Sources/Segment/Utilities/Retry/RetryStateMachine.swift
@@ -38,12 +38,18 @@ public class RetryStateMachine {
 
         // Exponential backoff for retryable errors
         let behavior = resolveStatusCodeBehavior(code: response.statusCode)
-        if behavior == .retry && config.backoffConfig.enabled {
+        if behavior == .retry {
             let currentTime = response.currentTime
-            return handleRetryableError(state: state, response: response, currentTime: currentTime)
+            // If server provided Retry-After, treat as pipeline-level rate limit regardless of status code
+            if response.retryAfterSeconds != nil && config.rateLimitConfig.enabled {
+                return handleRateLimitResponse(state: state, response: response, currentTime: currentTime)
+            }
+            if config.backoffConfig.enabled {
+                return handleRetryableError(state: state, response: response, currentTime: currentTime)
+            }
         }
 
-        // Drop non-retryable errors, or retryable errors when backoff is disabled
+        // Drop non-retryable errors, or retryable errors when both configs are disabled
         var newState = state
         newState.batchMetadata.removeValue(forKey: response.batchFile)
         return newState
@@ -125,8 +131,13 @@ public class RetryStateMachine {
         if statusCode == 429 && !config.rateLimitConfig.enabled { return true }
 
         let behavior = resolveStatusCodeBehavior(code: statusCode)
-        // Retryable error with backoff disabled: drop
-        if behavior == .retry && !config.backoffConfig.enabled { return true }
+        if behavior == .retry {
+            // Rate limit config handles retryable codes that carry Retry-After — don't drop
+            if config.rateLimitConfig.enabled { return false }
+            // Retryable error with backoff disabled and no rate-limit handling: drop
+            if !config.backoffConfig.enabled { return true }
+            return false
+        }
 
         return behavior == .drop
     }

--- a/Tests/Segment-Tests/Retry_Tests/RetryAfterGenericTests.swift
+++ b/Tests/Segment-Tests/Retry_Tests/RetryAfterGenericTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import Segment
+
+class RetryAfterGenericTests: XCTestCase {
+    var config: HttpConfig!
+    var timeProvider: FakeTimeProvider!
+    var stateMachine: RetryStateMachine!
+
+    override func setUp() {
+        super.setUp()
+        config = HttpConfig(
+            rateLimitConfig: RateLimitConfig(enabled: true, maxRetryCount: 100, maxRetryInterval: 300),
+            backoffConfig: BackoffConfig(enabled: true, maxRetryCount: 100, baseBackoffInterval: 0.5,
+                                        maxBackoffInterval: 300, maxTotalBackoffDuration: 43200, jitterPercent: 1)
+        )
+        timeProvider = FakeTimeProvider(currentTime: 1000)
+        stateMachine = RetryStateMachine(config: config, timeProvider: timeProvider)
+    }
+
+    // 529 + Retry-After:30 → pipelineState=.rateLimited, waitUntilTime=1030, globalRetryCount=1, batchMetadata nil
+    func test_529_withRetryAfter_triggersPipelinePause() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 529, retryAfterSeconds: 30, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertEqual(state.pipelineState, .rateLimited)
+        XCTAssertEqual(state.waitUntilTime, 1030.0)
+        XCTAssertEqual(state.globalRetryCount, 1)
+        XCTAssertNil(state.batchMetadata["batch1"])
+    }
+
+    // 529 + Retry-After:30 → batchMetadata nil (free retry, no failureCount)
+    func test_529_withRetryAfter_doesNotIncrementFailureCount() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 529, retryAfterSeconds: 30, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertNil(state.batchMetadata["batch1"])
+    }
+
+    // 503 + Retry-After:60 → pipeline-pause, waitUntilTime=1060
+    func test_503_withRetryAfter_triggersPipelinePause() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 503, retryAfterSeconds: 60, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertEqual(state.pipelineState, .rateLimited)
+        XCTAssertEqual(state.waitUntilTime, 1060.0)
+        XCTAssertEqual(state.globalRetryCount, 1)
+        XCTAssertNil(state.batchMetadata["batch1"])
+    }
+
+    // 408 + Retry-After:10 → pipeline-pause, waitUntilTime=1010
+    func test_408_withRetryAfter_triggersPipelinePause() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 408, retryAfterSeconds: 10, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertEqual(state.pipelineState, .rateLimited)
+        XCTAssertEqual(state.waitUntilTime, 1010.0)
+        XCTAssertEqual(state.globalRetryCount, 1)
+        XCTAssertNil(state.batchMetadata["batch1"])
+    }
+
+    // 529 + no Retry-After → falls into exponential backoff
+    func test_529_withoutRetryAfter_usesExponentialBackoff() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 529, retryAfterSeconds: nil, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertEqual(state.pipelineState, .ready)
+        XCTAssertNil(state.waitUntilTime)
+        XCTAssertEqual(state.globalRetryCount, 0)
+        XCTAssertNotNil(state.batchMetadata["batch1"])
+        XCTAssertEqual(state.batchMetadata["batch1"]?.failureCount, 1)
+    }
+
+    // 503 + no Retry-After → falls into backoff path
+    func test_503_withoutRetryAfter_usesExponentialBackoff() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 503, retryAfterSeconds: nil, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertEqual(state.pipelineState, .ready)
+        XCTAssertNil(state.waitUntilTime)
+        XCTAssertEqual(state.globalRetryCount, 0)
+        XCTAssertNotNil(state.batchMetadata["batch1"])
+        XCTAssertEqual(state.batchMetadata["batch1"]?.failureCount, 1)
+    }
+
+    // 529 + Retry-After:99999 → waitUntilTime=1300 (clamped to maxRetryInterval=300)
+    func test_retryAfter_clampedAtMaxRetryInterval() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 529, retryAfterSeconds: 99999, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertEqual(state.pipelineState, .rateLimited)
+        XCTAssertEqual(state.waitUntilTime, 1300.0)
+    }
+
+    // 529 + Retry-After:0 → pipelineState=.rateLimited, waitUntilTime=1000
+    func test_retryAfterZero_usesZeroWait() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 529, retryAfterSeconds: 0, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertEqual(state.pipelineState, .rateLimited)
+        XCTAssertEqual(state.waitUntilTime, 1000.0)
+    }
+
+    // 3 rate-limit responses → shouldUploadBatch returns dropBatch after cap
+    func test_globalRetryCountCapDropsBatchAfterMaxRetries() {
+        let cappedConfig = HttpConfig(
+            rateLimitConfig: RateLimitConfig(enabled: true, maxRetryCount: 3, maxRetryInterval: 300),
+            backoffConfig: BackoffConfig(enabled: true, maxRetryCount: 100, baseBackoffInterval: 0.5,
+                                        maxBackoffInterval: 300, maxTotalBackoffDuration: 43200, jitterPercent: 1)
+        )
+        let machine = RetryStateMachine(config: cappedConfig, timeProvider: timeProvider)
+        var state = RetryState()
+
+        for _ in 1...3 {
+            let response = ResponseInfo(statusCode: 529, retryAfterSeconds: 30, batchFile: "batch1", currentTime: 1000.0)
+            state = machine.handleResponse(state: state, response: response)
+        }
+
+        XCTAssertEqual(state.globalRetryCount, 3)
+        timeProvider.setTime(2000.0)
+
+        let (decision, _) = machine.shouldUploadBatch(state: state, batchFile: "batch1")
+        if case .dropBatch(let reason) = decision {
+            XCTAssertEqual(reason, .maxRetriesExceeded)
+        } else {
+            XCTFail("Expected dropBatch(reason: .maxRetriesExceeded), got \(decision)")
+        }
+    }
+
+    // 400 + Retry-After:60 → non-retryable, drops immediately
+    func test_400_withRetryAfter_dropsImmediately() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 400, retryAfterSeconds: 60, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertEqual(state.pipelineState, .ready)
+        XCTAssertNil(state.batchMetadata["batch1"])
+        XCTAssertNil(state.waitUntilTime)
+        XCTAssertEqual(state.globalRetryCount, 0)
+    }
+
+    // Regression guard: 429 + Retry-After:45 → unchanged behavior
+    func test_429_behaviorUnchanged() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 429, retryAfterSeconds: 45, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        XCTAssertEqual(state.pipelineState, .rateLimited)
+        XCTAssertEqual(state.waitUntilTime, 1045.0)
+        XCTAssertEqual(state.globalRetryCount, 1)
+    }
+
+    // 529 + Retry-After pause holds ALL batches, not just the triggering one
+    func test_pipelinePause_holdsAllBatches() {
+        var state = RetryState()
+        let response = ResponseInfo(statusCode: 529, retryAfterSeconds: 30, batchFile: "batch1", currentTime: 1000.0)
+        state = stateMachine.handleResponse(state: state, response: response)
+
+        let (decision1, _) = stateMachine.shouldUploadBatch(state: state, batchFile: "batch1")
+        let (decision2, _) = stateMachine.shouldUploadBatch(state: state, batchFile: "batch2")
+
+        if case .skipAllBatches = decision1 { } else {
+            XCTFail("Expected skipAllBatches for batch1, got \(decision1)")
+        }
+        if case .skipAllBatches = decision2 { } else {
+            XCTFail("Expected skipAllBatches for batch2, got \(decision2)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Any retryable HTTP response carrying a `Retry-After` header now triggers a pipeline-level pause, identical to 429 behavior
- Codes without `Retry-After` continue to use existing exponential backoff unchanged
- Emits a warning-level log when `Retry-After` triggers a pause on a non-429 code
- Existing 429 behavior is unchanged
- Fixed `shouldDropBatch` to correctly handle retryable codes when `rateLimitConfig.enabled = true, backoffConfig.enabled = false`

## Motivation

Per RFC 9110, `Retry-After` is a general-purpose header. Previously the SDK only respected it for 429. A 529 (or 503, 408, etc.) with `Retry-After` would be silently ignored and the SDK would compute its own (potentially shorter) backoff, increasing load on an already-overloaded server.

## Changes

- `RetryStateMachine.handleResponse()` — any retryable code with a non-nil `retryAfterSeconds` routes to `handleRateLimitResponse()` (pipeline pause, free retry) instead of `handleRetryableError()`
- `RetryStateMachine.shouldDropBatch()` — fixed to not drop batches for retryable codes when `rateLimitConfig.enabled`, regardless of `backoffConfig` state
- `HTTPClient` — warning log emitted on new pipeline pauses triggered by non-429 codes
- `RetryAfterGenericTests` — 12 new tests

## Test plan

- [x] `RetryAfterGenericTests` — all 12 tests pass
- [x] Full test suite (217 tests) passes with no regressions
- [ ] Manual: connect to test endpoint returning 529 + `Retry-After: 5`, observe pipeline pause in logs