### PR TITLE
Migrate CI to Twilio GHA macos-latest runners

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
   e2e-tests:
     # Skip on fork PRs where repo secrets aren't available
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: macos-latest
+    runs-on: macos-large-latest
 
     steps:
       - name: Checkout SDK

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           path: sdk
 
       - name: Checkout sdk-e2e-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: segmentio/sdk-e2e-tests
           ref: ${{ inputs.e2e_tests_ref || 'main' }}
@@ -42,7 +42,7 @@ jobs:
           path: sdk-e2e-tests
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-test-results
           path: sdk-e2e-tests/test-results/

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
   e2e-tests:
     # Skip on fork PRs where repo secrets aren't available
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: macos-large-latest
+    runs-on: macos-arm
 
     steps:
       - name: Checkout SDK

--- a/.github/workflows/publish-e2e-cli.yml
+++ b/.github/workflows/publish-e2e-cli.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   publish:
-    runs-on: macos-latest
+    runs-on: macos-large-latest
     steps:
       - name: Checkout SDK
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/publish-e2e-cli.yml
+++ b/.github/workflows/publish-e2e-cli.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   publish:
-    runs-on: macos-large-latest
+    runs-on: macos-arm
     steps:
       - name: Checkout SDK
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/publish-e2e-cli.yml
+++ b/.github/workflows/publish-e2e-cli.yml
@@ -22,14 +22,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Build e2e-cli (release)
         working-directory: e2e-cli
         run: swift build -c release
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-cli
           path: e2e-cli/.build/release/E2ECLI

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,133 +2,66 @@ name: Swift
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  cancel_previous:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: styfle/cancel-workflow-action@0.12.0
-        with:
-          workflow_id: ${{ github.event.workflow.id }}
-
-  generate_code_coverage:
-    needs: cancel_previous
-    runs-on: macos-26
-    steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
-      - name: Build & Run tests
-        run: swift test --enable-code-coverage
-      - name: Convert coverage report
-        run: xcrun llvm-cov export -format="lcov" .build/debug/SegmentPackageTests.xctest/Contents/MacOS/SegmentPackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: segmentio/analytics-swift
-
   build_and_test_spm_mac:
-    needs: cancel_previous
-    runs-on: macos-26
+    runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Build & Run tests
         run: swift test
 
   build_and_test_ios:
-    needs: cancel_previous
-    runs-on: macos-26
+    runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
-      - run: xcodebuild -scheme Segment test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17'
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - run: xcodebuild -scheme Segment test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16'
 
   build_and_test_tvos:
-    needs: cancel_previous
-    runs-on: macos-26
+    runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -sdk appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV'
 
   build_and_test_watchos:
-    needs: cancel_previous
-    runs-on: macos-26
+    runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
-      - run: xcodebuild -scheme Segment test -sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Ultra 3 (49mm)'
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - run: xcodebuild -scheme Segment test -sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)'
 
   build_and_test_visionos:
-    needs: cancel_previous
-    runs-on: macos-26
+    runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -destination 'platform=visionOS Simulator,OS=latest,name=Apple Vision Pro'
 
   build_and_test_examples:
-    needs: cancel_previous
-    runs-on: macos-26
+    runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SOVRAN_SSH_KEY }}
-      - name: build for ios simulator
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: BasicExample
         run: |
           cd Examples/apps/BasicExample
           xcodebuild -workspace "BasicExample.xcworkspace" -scheme "BasicExample" -sdk iphonesimulator
-      - name: build for ios simulator
+      - name: ObjCExample
         run: |
           cd Examples/apps/ObjCExample
           xcodebuild -workspace "ObjCExample.xcworkspace" -scheme "ObjCExample" -sdk iphonesimulator
-      - name: build for ios simulator
+      - name: SegmentUIKitExample
         run: |
           cd Examples/apps/SegmentUIKitExample
           xcodebuild -workspace "SegmentUIKitExample.xcworkspace" -scheme "SegmentUIKitExample" -sdk iphonesimulator
-      - name: build for ios simulator
+      - name: SegmentWeatherWidget
         run: |
           cd Examples/apps/SegmentWeatherWidget
           xcodebuild -workspace "SegmentWeatherWidget.xcworkspace" -scheme "SegmentWeatherWidget" -sdk iphonesimulator
-      - name: build for mac catalyst
+      - name: Mac Catalyst
         run: |
           cd Examples/apps/SegmentUIKitExample
           xcodebuild -workspace "SegmentUIKitExample.xcworkspace" -scheme "SegmentUIKitExample" -destination 'platform=macOS,variant=Mac Catalyst'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,14 +11,18 @@ concurrency:
 
 jobs:
   build_and_test_spm_mac:
-    runs-on: macos-large-latest
+    runs-on:
+      group: github-hosted-large
+      labels: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Build & Run tests
         run: swift test
 
   build_and_test_ios:
-    runs-on: macos-large-latest
+    runs-on:
+      group: github-hosted-large
+      labels: macos-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -43,7 +43,11 @@ jobs:
     runs-on: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - run: xcodebuild -scheme Segment test -destination 'platform=visionOS Simulator,OS=latest,name=Apple Vision Pro'
+      # The runner has no visionOS simulator runtime preinstalled — fetch it
+      # first. Probe: confirms whether this runner pool permits the download
+      # (i.e. has egress to Apple's platform CDN).
+      - run: xcodebuild -downloadPlatform visionOS
+      - run: xcodebuild -scheme Segment test -destination 'platform=visionOS Simulator,name=Apple Vision Pro'
 
   build_and_test_examples:
     runs-on: macos-large-latest

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,44 +11,38 @@ concurrency:
 
 jobs:
   build_and_test_spm_mac:
-    runs-on:
-      group: github-hosted-large
-      labels: macos-large-latest
+    runs-on: macos-arm
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Build & Run tests
         run: swift test
 
   build_and_test_ios:
-    runs-on:
-      group: github-hosted-large
-      labels: macos-large-latest
+    runs-on: macos-arm
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17'
 
   build_and_test_tvos:
-    runs-on: macos-large-latest
+    runs-on: macos-arm
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -sdk appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV'
 
   build_and_test_watchos:
-    runs-on: macos-large-latest
+    runs-on: macos-arm
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Ultra 3 (49mm)'
 
   build_and_test_visionos:
-    # visionOS's simulator is Apple-Silicon-only, so this job must run on an
-    # arm64 runner — on Intel it fails with "Could not find platform: visionOS".
     runs-on: macos-arm
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -destination 'platform=visionOS Simulator,name=Apple Vision Pro'
 
   build_and_test_examples:
-    runs-on: macos-large-latest
+    runs-on: macos-arm
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: BasicExample

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -43,9 +43,11 @@ jobs:
     runs-on: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      # The runner has no visionOS simulator runtime preinstalled — fetch it
-      # first. Probe: confirms whether this runner pool permits the download
-      # (i.e. has egress to Apple's platform CDN).
+      # The runner has no visionOS simulator runtime preinstalled. runFirstLaunch
+      # initializes Xcode's component/platform machinery (without it,
+      # -downloadPlatform reports "Could not find platform: visionOS"), then we
+      # fetch the runtime.
+      - run: sudo xcodebuild -runFirstLaunch
       - run: xcodebuild -downloadPlatform visionOS
       - run: xcodebuild -scheme Segment test -destination 'platform=visionOS Simulator,name=Apple Vision Pro'
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,15 +40,11 @@ jobs:
       - run: xcodebuild -scheme Segment test -sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Ultra 3 (49mm)'
 
   build_and_test_visionos:
-    runs-on: macos-large-latest
+    # visionOS's simulator is Apple-Silicon-only, so this job must run on an
+    # arm64 runner — on Intel it fails with "Could not find platform: visionOS".
+    runs-on: macos-arm
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      # The runner has no visionOS simulator runtime preinstalled. runFirstLaunch
-      # initializes Xcode's component/platform machinery (without it,
-      # -downloadPlatform reports "Could not find platform: visionOS"), then we
-      # fetch the runtime.
-      - run: sudo xcodebuild -runFirstLaunch
-      - run: xcodebuild -downloadPlatform visionOS
       - run: xcodebuild -scheme Segment test -destination 'platform=visionOS Simulator,name=Apple Vision Pro'
 
   build_and_test_examples:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,7 +25,7 @@ jobs:
       labels: macos-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - run: xcodebuild -scheme Segment test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16'
+      - run: xcodebuild -scheme Segment test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17'
 
   build_and_test_tvos:
     runs-on: macos-large-latest
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - run: xcodebuild -scheme Segment test -sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)'
+      - run: xcodebuild -scheme Segment test -sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Ultra 3 (49mm)'
 
   build_and_test_visionos:
     runs-on: macos-large-latest

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,38 +11,38 @@ concurrency:
 
 jobs:
   build_and_test_spm_mac:
-    runs-on: macos-latest
+    runs-on: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Build & Run tests
         run: swift test
 
   build_and_test_ios:
-    runs-on: macos-latest
+    runs-on: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16'
 
   build_and_test_tvos:
-    runs-on: macos-latest
+    runs-on: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -sdk appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV'
 
   build_and_test_watchos:
-    runs-on: macos-latest
+    runs-on: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)'
 
   build_and_test_visionos:
-    runs-on: macos-latest
+    runs-on: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -destination 'platform=visionOS Simulator,OS=latest,name=Apple Vision Pro'
 
   build_and_test_examples:
-    runs-on: macos-latest
+    runs-on: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: BasicExample

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,7 +22,7 @@ jobs:
   build_and_test_ios:
     runs-on:
       group: github-hosted-large
-      labels: macos-latest
+      labels: macos-large-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme Segment test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17'


### PR DESCRIPTION
- Replace macos-26 with macos-latest
- Remove blocked third-party actions (setup-xcode, ssh-agent, cancel-workflow-action, codecov)
- Use native concurrency group for workflow cancellation
- Remove SSH agent (sovran-swift and jsonsafeencoding-swift are public)
- Update actions/checkout to v4